### PR TITLE
gcr.io/google-containers -> k8s.gcr.io

### DIFF
--- a/pkg/converter/converter_test.go
+++ b/pkg/converter/converter_test.go
@@ -38,7 +38,7 @@ spec:
     - sh
     - -c
     - exec /rescheduler --running-in-cluster=false 1>>/var/log/rescheduler.log 2>&1
-    image: gcr.io/google-containers/rescheduler:v0.3.1
+    image: k8s.gcr.io/rescheduler:v0.3.1
     name: rescheduler
     resources:
       requests:

--- a/pkg/patch/patch_test.go
+++ b/pkg/patch/patch_test.go
@@ -67,7 +67,7 @@ spec:
     - exec /usr/local/bin/kube-apiserver
       --advertise-address=$(ADVERTISE_ADDRESS)
       --storage-backend=$(ETCD_BACKEND)
-    image: gcr.io/google_containers/kube-apiserver:v1.9.7
+    image: k8s.gcr.io/kube-apiserver:v1.9.7
     env:
     - name: ADVERTISE_ADDRESS
       value: 10.0.0.1

--- a/pkg/testutil/testdata/etcd-server.yaml
+++ b/pkg/testutil/testdata/etcd-server.yaml
@@ -52,7 +52,7 @@ spec:
       value: http://127.0.0.1:2379
     - name: ETCD_CREDS
       value: ""
-    image: gcr.io/google_containers/etcd:3.1.11
+    image: k8s.gcr.io/etcd:3.1.11
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/pkg/testutil/testdata/kube-apiserver.yaml
+++ b/pkg/testutil/testdata/kube-apiserver.yaml
@@ -70,7 +70,7 @@ spec:
       --authorization-mode=Node,RBAC,Webhook
       --allow-privileged=true 1>>/var/log/kube-apiserver.log
       2>&1
-    image: gcr.io/google_containers/kube-apiserver:v1.9.7
+    image: k8s.gcr.io/kube-apiserver:v1.9.7
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/pkg/testutil/testdata/kube-controller-manager.yaml
+++ b/pkg/testutil/testdata/kube-controller-manager.yaml
@@ -38,7 +38,7 @@ spec:
       --allocate-node-cidrs=true
       --terminated-pod-gc-threshold=1000
       1>>/var/log/kube-controller-manager.log 2>&1
-    image: gcr.io/google_containers/kube-controller-manager:v1.9.7
+    image: k8s.gcr.io/kube-controller-manager:v1.9.7
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/pkg/testutil/testdata/kube-scheduler.yaml
+++ b/pkg/testutil/testdata/kube-scheduler.yaml
@@ -27,7 +27,7 @@ spec:
     - -c
     - exec /usr/local/bin/kube-scheduler --v=2  --kubeconfig=/etc/srv/kubernetes/kube-scheduler/kubeconfig
       1>>/var/log/kube-scheduler.log 2>&1
-    image: gcr.io/google_containers/kube-scheduler:v1.9.7
+    image: k8s.gcr.io/kube-scheduler:v1.9.7
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/pkg/testutil/testdata/kubedns/deployment.yaml
+++ b/pkg/testutil/testdata/kubedns/deployment.yaml
@@ -46,7 +46,7 @@ spec:
           optional: true
       containers:
       - name: kubedns
-        image: gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.10
+        image: k8s.gcr.io/k8s-dns-kube-dns-amd64:1.14.10
         resources:
           limits:
             memory: 170Mi
@@ -91,7 +91,7 @@ spec:
         - name: kube-dns-config
           mountPath: /kube-dns-config
       - name: dnsmasq
-        image: gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.10
+        image: k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64:1.14.10
         livenessProbe:
           httpGet:
             path: /healthcheck/dnsmasq
@@ -129,7 +129,7 @@ spec:
         - name: kube-dns-config
           mountPath: /etc/k8s/dns/dnsmasq-nanny
       - name: sidecar
-        image: gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.10
+        image: k8s.gcr.io/k8s-dns-sidecar-amd64:1.14.10
         livenessProbe:
           httpGet:
             path: /metrics

--- a/pkg/testutil/testdata/kubedns/kubedns-full.yaml
+++ b/pkg/testutil/testdata/kubedns/kubedns-full.yaml
@@ -85,7 +85,7 @@ spec:
           optional: true
       containers:
       - name: kubedns
-        image: gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.10
+        image: k8s.gcr.io/k8s-dns-kube-dns-amd64:1.14.10
         resources:
           limits:
             memory: 170Mi
@@ -130,7 +130,7 @@ spec:
         - name: kube-dns-config
           mountPath: /kube-dns-config
       - name: dnsmasq
-        image: gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.10
+        image: k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64:1.14.10
         livenessProbe:
           httpGet:
             path: /healthcheck/dnsmasq
@@ -168,7 +168,7 @@ spec:
         - name: kube-dns-config
           mountPath: /etc/k8s/dns/dnsmasq-nanny
       - name: sidecar
-        image: gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.10
+        image: k8s.gcr.io/k8s-dns-sidecar-amd64:1.14.10
         livenessProbe:
           httpGet:
             path: /metrics
@@ -193,7 +193,7 @@ spec:
             cpu: 10m
       # CUSTOM PORTION
       - name: prometheus-to-sd
-        image: gcr.io/google-containers/prometheus-to-sd:v0.2.3
+        image: k8s.gcr.io/prometheus-to-sd:v0.2.3
         command:
           - /monitor
           - --component=kubedns


### PR DESCRIPTION
Use the real repo, rather than rely on one of GCR's docker bug mitigations