### PR TITLE
Add a relatively simple command to filter objects, components

### DIFF
--- a/pkg/commands/BUILD.bazel
+++ b/pkg/commands/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     deps = [
         "//pkg/commands/cmdlib:go_default_library",
         "//pkg/commands/export:go_default_library",
+        "//pkg/commands/filter:go_default_library",
         "//pkg/commands/find:go_default_library",
         "//pkg/commands/inline:go_default_library",
         "//pkg/commands/modify:go_default_library",

--- a/pkg/commands/filter/BUILD.bazel
+++ b/pkg/commands/filter/BUILD.bazel
@@ -1,0 +1,19 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "add_commands.go",
+        "doc.go",
+        "filter.go",
+    ],
+    importpath = "github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/commands/filter",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/commands/cmdlib:go_default_library",
+        "//pkg/converter:go_default_library",
+        "//pkg/filter:go_default_library",
+        "//vendor/github.com/golang/glog:go_default_library",
+        "//vendor/github.com/spf13/cobra:go_default_library",
+    ],
+)

--- a/pkg/commands/filter/add_commands.go
+++ b/pkg/commands/filter/add_commands.go
@@ -1,0 +1,50 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filter
+
+import (
+	"context"
+
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/commands/cmdlib"
+	"github.com/spf13/cobra"
+)
+
+// AddCommandsTo adds commands to a root cobra command.
+func AddCommandsTo(ctx context.Context, root *cobra.Command) {
+	cmd := &cobra.Command{
+		Use:   "filter",
+		Short: "Filter the components or objects in a bundle file",
+		Long:  `Filter the components or objects in a bundle file, returning a new bundle file`,
+		Run:   cmdlib.ContextAction(ctx, action),
+	}
+
+	// Optional flags
+	cmd.Flags().StringVarP(&opts.filterType, "filter-type", "", "objects",
+		"Whether to filter components or objects")
+	cmd.Flags().StringVarP(&opts.kinds, "kinds", "", "",
+		"Comma separated kinds to filter on")
+	cmd.Flags().StringVarP(&opts.names, "names", "", "",
+		"Comma separated names to filter on")
+	cmd.Flags().StringVarP(&opts.namespaces, "namespaces", "", "",
+		"Comma separated namespaces to filter on")
+	cmd.Flags().StringVarP(&opts.annotations, "annotations", "", "",
+		"Comma + semicolon separated annotations to filter on. Ex: 'foo,bar;biff,bam'")
+	cmd.Flags().StringVarP(&opts.labels, "labels", "", "",
+		"Comma + semicolon separated labelsto filter on. Ex: 'foo,bar;biff,bam'")
+	cmd.Flags().BoolVarP(&opts.keepOnly, "keep-only", "", false,
+		"Whether to keep options instead of filtering them")
+
+	root.AddCommand(cmd)
+}

--- a/pkg/commands/filter/doc.go
+++ b/pkg/commands/filter/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package filter contains commands for filtering components and objects.
+package filter

--- a/pkg/commands/filter/filter.go
+++ b/pkg/commands/filter/filter.go
@@ -1,0 +1,114 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filter
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/commands/cmdlib"
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/converter"
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/filter"
+	log "github.com/golang/glog"
+	"github.com/spf13/cobra"
+)
+
+// options represents options flags for the filter command.
+type options struct {
+	// Either 'components' or 'objects'. Defaults to components.
+	filterType string
+
+	// Comma-separated kinds to filter
+	kinds string
+
+	// Comma-separated names to filter
+	names string
+
+	// Comma-separated namespaces to filter
+	namespaces string
+
+	// Comma + semicolon separated annotations to filter
+	// Example: foo,bar;biff,bam
+	annotations string
+
+	// Comma + semicolon separated annotations to filter
+	// Example: foo,bar;biff,bam
+	labels string
+
+	// Whether to keep matches rather then remove them.
+	keepOnly bool
+}
+
+// opts is a global options instance for reference via the add commands.
+var opts = &options{}
+
+func action(ctx context.Context, cmd *cobra.Command, _ []string) {
+	gopt := cmdlib.GlobalOptionsValues.Copy()
+	gopt.Inline = true
+	brw := converter.NewFileSystemBundleReaderWriter()
+	if err := run(ctx, opts, brw, gopt); err != nil {
+		log.Exit(err)
+	}
+}
+
+func run(ctx context.Context, o *options, brw *converter.BundleReaderWriter, gopt *cmdlib.GlobalOptions) error {
+	b, err := cmdlib.ReadBundleContents(ctx, brw.RW, gopt)
+	if err != nil {
+		return fmt.Errorf("error reading bundle contents: %v", err)
+	}
+
+	fopts := &filter.Options{}
+	if o.kinds != "" {
+		fopts.Kinds = strings.Split(o.kinds, ",")
+	}
+	if o.names != "" {
+		fopts.Names = strings.Split(o.names, ",")
+	}
+	if o.namespaces != "" {
+		fopts.Namespaces = strings.Split(o.namespaces, ",")
+	}
+	if o.annotations != "" {
+		m := make(map[string]string)
+		splat := strings.Split(o.annotations, ";")
+		for _, v := range splat {
+			kv := strings.Split(v, ",")
+			if len(kv) == 2 {
+				m[kv[0]] = kv[1]
+			}
+		}
+		fopts.Annotations = m
+	}
+	if o.labels != "" {
+		m := make(map[string]string)
+		splat := strings.Split(o.labels, ";")
+		for _, v := range splat {
+			kv := strings.Split(v, ",")
+			if len(kv) == 2 {
+				m[kv[0]] = kv[1]
+			}
+		}
+		fopts.Labels = m
+	}
+	fopts.KeepOnly = o.keepOnly
+
+	if o.filterType == "components" {
+		b = (&filter.Filterer{b}).FilterComponents(fopts)
+	} else {
+		b = (&filter.Filterer{b}).FilterObjects(fopts)
+	}
+
+	return cmdlib.WriteStructuredContents(ctx, b, brw.RW, gopt)
+}

--- a/pkg/commands/root.go
+++ b/pkg/commands/root.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/commands/cmdlib"
 	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/commands/export"
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/commands/filter"
 	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/commands/find"
 	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/commands/inline"
 	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/commands/modify"
@@ -57,6 +58,7 @@ func AddCommands(ctx context.Context, args []string) *cobra.Command {
 		&cmdlib.GlobalOptionsValues.TopLayerInlineOnly, "only-inline-top", "", false, "Whether to inline just the top layer of the bundle (node config and component files)")
 
 	export.AddCommandsTo(ctx, rootCmd)
+	filter.AddCommandsTo(ctx, rootCmd)
 	find.AddCommandsTo(ctx, rootCmd)
 	inline.AddCommandsTo(ctx, rootCmd)
 	modify.AddCommandsTo(ctx, rootCmd)

--- a/pkg/filter/BUILD.bazel
+++ b/pkg/filter/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -13,5 +13,16 @@ go_library(
         "//pkg/converter:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/github.com/golang/protobuf/ptypes/struct:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["filter_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//pkg/apis/bundle/v1alpha1:go_default_library",
+        "//pkg/converter:go_default_library",
+        "//pkg/core:go_default_library",
     ],
 )

--- a/pkg/filter/BUILD.bazel
+++ b/pkg/filter/BUILD.bazel
@@ -1,0 +1,17 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "doc.go",
+        "filter.go",
+    ],
+    importpath = "github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/filter",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/apis/bundle/v1alpha1:go_default_library",
+        "//pkg/converter:go_default_library",
+        "//vendor/github.com/golang/glog:go_default_library",
+        "//vendor/github.com/golang/protobuf/ptypes/struct:go_default_library",
+    ],
+)

--- a/pkg/filter/doc.go
+++ b/pkg/filter/doc.go
@@ -12,5 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package files contains methods and data types for manipulating files.
-package files
+// Package filter contains methods for filtering bundles.
+package filter

--- a/pkg/filter/filter.go
+++ b/pkg/filter/filter.go
@@ -1,0 +1,143 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filter
+
+import (
+	bpb "github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/apis/bundle/v1alpha1"
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/converter"
+	log "github.com/golang/glog"
+	structpb "github.com/golang/protobuf/ptypes/struct"
+)
+
+// Filterer filters the components and objects in bundles to produce new,
+// smaller bundles
+type Filterer struct {
+	b *bpb.ClusterBundle
+}
+
+// Options for filtering bundles. By default, if any of the options match, then
+// the relevant component or object is removed. If KeepOnly is set, then the
+// objects are kept instead of removed.
+type Options struct {
+	// Kinds represent the Kinds to filter on.
+	Kinds []string
+
+	// Names represent the metadata.names to filter on.
+	Names []string
+
+	// Annotations contain key/value pairs to filter on. An empty string value matches
+	// all annotation-values for a particular key.
+	Annotations map[string]string
+
+	// Labels contain key/value pairs to filter on. An empty string value matches
+	// all label-values for a particular key.
+	Labels map[string]string
+
+	// KeepOnly means that instead of removing the found objects.
+	KeepOnly bool
+}
+
+// FilterComponents filters components based on the ObjectMeta properties of
+// the components, returning a new cluster bundle with just filtered
+// components. By default components are removed, unless KeepOnly is set, and
+// then the opposite is true. Filtering for components doesn't take into
+// account the properties of the object-children of the components.
+func FilterComponents(b *bpb.ClusterBundle, o *Options) *bpb.ClusterBundle {
+	b = converter.CloneBundle(b)
+	if b.GetSpec() == nil {
+		return b
+	}
+	var matched []*bpb.ClusterComponent
+	var notMatched []*bpb.ClusterComponent
+	for _, c := range b.GetSpec().GetComponents() {
+		matches := filterMeta(c.GetKind(), c.GetMetadata(), o)
+		if matches {
+			matched = append(matched, c)
+		} else {
+			notMatched = append(notMatched, c)
+		}
+	}
+	if o.KeepOnly {
+		b.GetSpec().Components = matched
+		return b
+	}
+	b.GetSpec().Components = notMatched
+	return b
+}
+
+// FilterObjects filters objects based on the ObjectMeta properties of
+// the objects, returning a new cluster bundle with just filtered
+// objects. By default objectsare removed, unless KeepOnly is set, and
+// then the opposite is true.
+func FilterObjects(b *bpb.ClusterBundle, o *Options) *bpb.ClusterBundle {
+	b = converter.CloneBundle(b)
+	if b.GetSpec() == nil {
+		return b
+	}
+	for _, cp := range b.GetSpec().GetComponents() {
+		var matched []*structpb.Struct
+		var notMatched []*structpb.Struct
+		for _, c := range cp.GetClusterObjects() {
+			meta, err := converter.ObjectMetaFromStruct(c)
+			if err != nil {
+				log.Infof("error converting cluster's object meta: %v", err)
+				// If this happens, then likely, the structure is invalid of the
+				// ObjectMeta.
+				continue
+			}
+			matches := filterMeta(c.GetFields()["kind"].GetStringValue(), meta, o)
+			if matches {
+				matched = append(matched, c)
+			} else {
+				notMatched = append(notMatched, c)
+			}
+		}
+		if o.KeepOnly {
+			cp.ClusterObjects = matched
+		} else {
+			cp.ClusterObjects = notMatched
+		}
+	}
+	return b
+}
+
+func filterMeta(kind string, meta *bpb.ObjectMeta, o *Options) bool {
+	for _, k := range o.Kinds {
+		if k == kind {
+			return true
+		}
+	}
+	// We ignore kind, because Kind should always be cluster bundle.
+	for _, n := range o.Names {
+		if meta.GetName() == n {
+			return true
+		}
+	}
+	if len(meta.Annotations) > 0 {
+		for key, v := range o.Annotations {
+			if val, ok := meta.Annotations[key]; ok && val == v {
+				return true
+			}
+		}
+	}
+	if len(meta.Labels) > 0 {
+		for key, v := range o.Labels {
+			if val, ok := meta.Labels[key]; ok && val == v {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/pkg/filter/filter_test.go
+++ b/pkg/filter/filter_test.go
@@ -1,0 +1,379 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filter
+
+import (
+	"reflect"
+	"testing"
+
+	bpb "github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/apis/bundle/v1alpha1"
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/converter"
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/core"
+)
+
+var example = `
+apiVersion: 'bundle.k8s.io/v1alpha1'
+kind: ClusterBundle
+metadata:
+  name: '1.9.7.testbundle-zork'
+spec:
+  components:
+  - metadata:
+      name: zap
+    clusterObjects:
+    - apiVersion: v1
+      kind: Pod
+      metadata:
+        name: zap-pod
+        labels:
+          component: zork
+        annotations:
+          foo: bar
+        namespace: kube-system
+  - metadata:
+      name: bog
+    clusterObjects:
+    - apiVersion: v1
+      kind: Pod
+      metadata:
+        name: bog-pod
+        labels:
+          component: bork
+        annotations:
+          foof: yar
+        namespace: kube-system
+  - metadata:
+      name: nog
+    clusterObjects:
+    - apiVersion: v1
+      kind: Pod
+      metadata:
+        name: nog-pod
+        labels:
+          component: nork
+        annotations:
+          foof: narf
+        namespace: kube
+  - metadata:
+      name: zog
+    clusterObjects:
+    - apiVersion: v1
+      kind: Deployment
+      metadata:
+        name: zog-dep
+        labels:
+          component: zork
+        annotations:
+          zoof: zarf
+        namespace: zube`
+
+func TestFilterObjects(t *testing.T) {
+	testcases := []struct {
+		desc        string
+		opt         *Options
+		expObjNames []string
+	}{
+		{
+			desc:        "fiter-success: no change",
+			opt:         &Options{},
+			expObjNames: []string{"zap-pod", "bog-pod", "nog-pod", "zog-dep"},
+		},
+		{
+			desc: "fiter-success: name filter",
+			opt: &Options{
+				Names: []string{"zap-pod"},
+			},
+			expObjNames: []string{"bog-pod", "nog-pod", "zog-dep"},
+		},
+		{
+			desc: "fiter-success: labels filter",
+			opt: &Options{
+				Labels: map[string]string{
+					"component": "bork",
+				},
+			},
+			expObjNames: []string{"zap-pod", "nog-pod", "zog-dep"},
+		},
+		{
+			desc: "fiter-success: annotations filter",
+			opt: &Options{
+				Annotations: map[string]string{
+					"foof": "narf",
+				},
+			},
+			expObjNames: []string{"zap-pod", "bog-pod", "zog-dep"},
+		},
+		{
+			desc: "fiter-success: namespace filter",
+			opt: &Options{
+				Namespaces: []string{"kube-system"},
+			},
+			expObjNames: []string{"nog-pod", "zog-dep"},
+		},
+		{
+			desc: "fiter-success: kind filter",
+			opt: &Options{
+				Kinds: []string{"Pod"},
+			},
+			expObjNames: []string{"zog-dep"},
+		},
+
+		// KeepOnly
+		{
+			desc: "fiter-success keeponly: empty",
+			opt: &Options{
+				KeepOnly: true,
+			},
+		},
+		{
+			desc: "fiter-success keeponly: name filter",
+			opt: &Options{
+				Names:    []string{"zap-pod"},
+				KeepOnly: true,
+			},
+			expObjNames: []string{"zap-pod"},
+		},
+		{
+			desc: "fiter-success keeponly: labels filter",
+			opt: &Options{
+				Labels: map[string]string{
+					"component": "bork",
+				},
+				KeepOnly: true,
+			},
+			expObjNames: []string{"bog-pod"},
+		},
+		{
+			desc: "fiter-success keeponly: annotations filter",
+			opt: &Options{
+				Annotations: map[string]string{
+					"foof": "narf",
+				},
+				KeepOnly: true,
+			},
+			expObjNames: []string{"nog-pod"},
+		},
+		{
+			desc: "fiter-success keeponly: namespace filter",
+			opt: &Options{
+				Namespaces: []string{"kube-system"},
+				KeepOnly:   true,
+			},
+			expObjNames: []string{"zap-pod", "bog-pod"},
+		},
+		{
+			desc: "fiter-success keeponly: kind filter",
+			opt: &Options{
+				Kinds:    []string{"Pod"},
+				KeepOnly: true,
+			},
+			expObjNames: []string{"zap-pod", "bog-pod", "nog-pod"},
+		},
+	}
+
+	b, err := converter.Bundle.YAMLToProto([]byte(example))
+	if err != nil {
+		t.Fatalf("error converting bundle: %v", err)
+	}
+	bun := converter.ToBundle(b)
+	for _, tc := range testcases {
+		t.Run(tc.desc, func(t *testing.T) {
+			f := &Filterer{bun}
+			newb := f.FilterObjects(tc.opt)
+			onames := getObjNames(newb)
+			if !reflect.DeepEqual(onames, tc.expObjNames) {
+				t.Errorf("FilterObjects(): got %v but wanted %v", onames, tc.expObjNames)
+			}
+		})
+	}
+}
+
+func getObjNames(b *bpb.ClusterBundle) []string {
+	var names []string
+	for _, c := range b.GetSpec().GetComponents() {
+		for _, o := range c.GetClusterObjects() {
+			names = append(names, core.ObjectName(o))
+		}
+	}
+	return names
+}
+
+var componentExample = `
+apiVersion: 'bundle.k8s.io/v1alpha1'
+kind: ClusterBundle
+metadata:
+  name: '1.9.7.testbundle-zork'
+spec:
+  components:
+  - kind: ClusterComponent
+    metadata:
+      name: zap-pod
+      labels:
+        component: zork
+      annotations:
+        foo: bar
+      namespace: kube-system
+  - kind: ClusterComponent
+    metadata:
+      name: bog-pod
+      labels:
+        component: bork
+      annotations:
+        foof: yar
+      namespace: kube-system
+  - kind: ClusterComponent
+    metadata:
+      name: nog-pod
+      labels:
+        component: nork
+      annotations:
+        foof: narf
+      namespace: kube
+  - kind: ClusterComponent
+    metadata:
+      name: zog-dep
+      labels:
+        component: zork
+      annotations:
+        zoof: zarf
+      namespace: zube`
+
+func TestFilterComponents(t *testing.T) {
+	testcases := []struct {
+		desc        string
+		opt         *Options
+		expObjNames []string
+	}{
+		{
+			desc:        "fiter-success: no change",
+			opt:         &Options{},
+			expObjNames: []string{"zap-pod", "bog-pod", "nog-pod", "zog-dep"},
+		},
+		{
+			desc: "fiter-success: name filter",
+			opt: &Options{
+				Names: []string{"zap-pod"},
+			},
+			expObjNames: []string{"bog-pod", "nog-pod", "zog-dep"},
+		},
+		{
+			desc: "fiter-success: labels filter",
+			opt: &Options{
+				Labels: map[string]string{
+					"component": "bork",
+				},
+			},
+			expObjNames: []string{"zap-pod", "nog-pod", "zog-dep"},
+		},
+		{
+			desc: "fiter-success: annotations filter",
+			opt: &Options{
+				Annotations: map[string]string{
+					"foof": "narf",
+				},
+			},
+			expObjNames: []string{"zap-pod", "bog-pod", "zog-dep"},
+		},
+		{
+			desc: "fiter-success: namespace filter",
+			opt: &Options{
+				Namespaces: []string{"kube-system"},
+			},
+			expObjNames: []string{"nog-pod", "zog-dep"},
+		},
+		{
+			desc: "fiter-success: kind filter",
+			opt: &Options{
+				Kinds: []string{"ClusterComponent"},
+			},
+		},
+
+		// KeepOnly
+		{
+			desc: "fiter-success keeponly: empty",
+			opt: &Options{
+				KeepOnly: true,
+			},
+		},
+		{
+			desc: "fiter-success keeponly: name filter",
+			opt: &Options{
+				Names:    []string{"zap-pod"},
+				KeepOnly: true,
+			},
+			expObjNames: []string{"zap-pod"},
+		},
+		{
+			desc: "fiter-success keeponly: labels filter",
+			opt: &Options{
+				Labels: map[string]string{
+					"component": "bork",
+				},
+				KeepOnly: true,
+			},
+			expObjNames: []string{"bog-pod"},
+		},
+		{
+			desc: "fiter-success keeponly: annotations filter",
+			opt: &Options{
+				Annotations: map[string]string{
+					"foof": "narf",
+				},
+				KeepOnly: true,
+			},
+			expObjNames: []string{"nog-pod"},
+		},
+		{
+			desc: "fiter-success keeponly: namespace filter",
+			opt: &Options{
+				Namespaces: []string{"kube-system"},
+				KeepOnly:   true,
+			},
+			expObjNames: []string{"zap-pod", "bog-pod"},
+		},
+		{
+			desc: "fiter-success keeponly: kind filter",
+			opt: &Options{
+				Kinds:    []string{"ClusterComponent"},
+				KeepOnly: true,
+			},
+			expObjNames: []string{"zap-pod", "bog-pod", "nog-pod", "zog-dep"},
+		},
+	}
+
+	b, err := converter.Bundle.YAMLToProto([]byte(componentExample))
+	if err != nil {
+		t.Fatalf("error converting bundle: %v", err)
+	}
+	bun := converter.ToBundle(b)
+	for _, tc := range testcases {
+		t.Run(tc.desc, func(t *testing.T) {
+			f := &Filterer{bun}
+			newb := f.FilterComponents(tc.opt)
+			onames := getCompObjNames(newb)
+			if !reflect.DeepEqual(onames, tc.expObjNames) {
+				t.Errorf("FilterObjects(): got %v but wanted %v", onames, tc.expObjNames)
+			}
+		})
+	}
+}
+
+func getCompObjNames(b *bpb.ClusterBundle) []string {
+	var names []string
+	for _, c := range b.GetSpec().GetComponents() {
+		names = append(names, c.GetMetadata().GetName())
+	}
+	return names
+}


### PR DESCRIPTION
This PR adds a relatively simple command to filter objects, components from bundles.

An example of use:

```
bundlectl filter -f example-bundle.yaml --filter-type=objects --namespaces=kube-system
```

Removes all objects with namespace=kube-system

```
bundlectl filter -f example-bundle.yaml --filter-type=objects --namespaces=kube-system --keep-only
```

Keeps only objects with namespace=kube-system.