### PR TITLE
Add smart object lookup.

### DIFF
--- a/pkg/converter/example_test.go
+++ b/pkg/converter/example_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 const bundleSimple = `
-apiVersion: 'bundle.k8s.io/v1alpha1'
+apiVersion: 'gke.io/k8s-cluster-bundle/v1alpha1'
 kind: ClusterBundle
 metadata:
   name: test-bundle

--- a/pkg/converter/kube.go
+++ b/pkg/converter/kube.go
@@ -16,10 +16,7 @@ package converter
 
 import (
 	"encoding/json"
-	"fmt"
-	"regexp"
 
-	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/core"
 	structpb "github.com/golang/protobuf/ptypes/struct"
 	apiextv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 )
@@ -48,40 +45,4 @@ func (k *KubeConverter) ToCRD() (*apiextv1beta1.CustomResourceDefinition, error)
 	}
 
 	return crd, nil
-}
-
-// ToObjectRef converts a Kubernetes object to an object reference.
-// TODO(kashomon): deduplicate with ObjectRefFromRawKubeResource
-func (k *KubeConverter) ToObjectRef() (core.ObjectReference, error) {
-	nullResp := core.ObjectReference{}
-	ref := core.ObjectReference{}
-	apiVersion := k.s.GetFields()["apiVersion"].GetStringValue()
-	if apiVersion == "" {
-		return nullResp, fmt.Errorf("no apiVersion field was found for Kubernetes resource %v", k.s)
-	}
-	matches := regexp.MustCompile("(.+)/(.+)").FindStringSubmatch(apiVersion)
-	if matches == nil || len(matches) != 3 {
-		return nullResp, fmt.Errorf("Kubernetes resource apiVersion is not formatted as group/version: got %q", apiVersion)
-	}
-	ref.APIVersion = apiVersion
-
-	kind := k.s.GetFields()["kind"].GetStringValue()
-	if kind == "" {
-		return nullResp, fmt.Errorf("no kind field was found for Kubernetes resource %v", k.s)
-	}
-	ref.Kind = kind
-
-	md := k.s.GetFields()["metadata"]
-	if md == nil {
-		return nullResp, fmt.Errorf("no metadata field was found for Kubernetes resource %v", k.s)
-	}
-
-	metadata := md.GetStructValue()
-	name := metadata.GetFields()["name"].GetStringValue()
-	if name == "" {
-		return nullResp, fmt.Errorf("no metadata.name field was found for Kubernetes resource %v", k.s)
-	}
-
-	ref.Name = name
-	return ref, nil
 }

--- a/pkg/core/core.go
+++ b/pkg/core/core.go
@@ -29,8 +29,8 @@ type ClusterObjectKey struct {
 
 var EmptyClusterObjectKey = ClusterObjectKey{}
 
-// ObjectReference is a stripped-down version of the Kubernetes corev1.ObjectReference type.
-type ObjectReference struct {
+// ObjectRef is a stripped-down version of the Kubernetes corev1.ObjectReference type.
+type ObjectRef struct {
 	// The API Version for an Object.
 	APIVersion string
 
@@ -41,8 +41,8 @@ type ObjectReference struct {
 	Name string
 }
 
-func ObjectRefFromStruct(o *structpb.Struct) ObjectReference {
-	return ObjectReference{
+func ObjectRefFromStruct(o *structpb.Struct) ObjectRef {
+	return ObjectRef{
 		APIVersion: ObjectAPIVersion(o),
 		Kind:       ObjectKind(o),
 		Name:       ObjectName(o),

--- a/pkg/filter/filter_test.go
+++ b/pkg/filter/filter_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 var example = `
-apiVersion: 'bundle.k8s.io/v1alpha1'
+apiVersion: 'gke.io/k8s-cluster-bundle/v1alpha1'
 kind: ClusterBundle
 metadata:
   name: '1.9.7.testbundle-zork'
@@ -211,7 +211,7 @@ func getObjNames(b *bpb.ClusterBundle) []string {
 }
 
 var componentExample = `
-apiVersion: 'bundle.k8s.io/v1alpha1'
+apiVersion: 'gke.io/k8s-cluster-bundle/v1alpha1'
 kind: ClusterBundle
 metadata:
   name: '1.9.7.testbundle-zork'

--- a/pkg/find/images_test.go
+++ b/pkg/find/images_test.go
@@ -160,7 +160,7 @@ func TestImageFinder_MultipleImages(t *testing.T) {
 }
 
 var bundleExample = `
-apiVersion: 'bundle.k8s.io/v1alpha1'
+apiVersion: 'gke.io/k8s-cluster-bundle/v1alpha1'
 kind: ClusterBundle
 metadata:
   name: '1.9.7.testbundle-zork'
@@ -237,7 +237,7 @@ func TestImageFinder_Bundle(t *testing.T) {
 }
 
 var bundleExampleNodeConfig = `
-apiVersion: 'bundle.k8s.io/v1alpha1'
+apiVersion: 'gke.io/k8s-cluster-bundle/v1alpha1'
 kind: ClusterBundle
 metadata:
   name: '1.9.7.testbundle-zork'
@@ -282,7 +282,7 @@ func TestImageFinder_NodeImages(t *testing.T) {
 }
 
 var bundleExampleAll = `
-apiVersion: 'bundle.k8s.io/v1alpha1'
+apiVersion: 'gke.io/k8s-cluster-bundle/v1alpha1'
 kind: ClusterBundle
 metadata:
   name: '1.9.7.testbundle-zork'

--- a/pkg/transformer/export_test.go
+++ b/pkg/transformer/export_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 const inlinedBundle = `
-apiVersion: 'bundle.k8s.io/v1alpha1'
+apiVersion: 'gke.io/k8s-cluster-bundle/v1alpha1'
 kind: ClusterBundle
 metadata:
   name: inlined-bundle
@@ -52,7 +52,7 @@ spec:
 `
 
 const filesBundle = `
-apiVersion: 'bundle.k8s.io/v1alpha1'
+apiVersion: 'gke.io/k8s-cluster-bundle/v1alpha1'
 kind: ClusterBundle
 metadata:
   name: files-bundle

--- a/pkg/transformer/images_test.go
+++ b/pkg/transformer/images_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 var bundleExampleAll = `
-apiVersion: 'bundle.k8s.io/v1alpha1'
+apiVersion: 'gke.io/k8s-cluster-bundle/v1alpha1'
 kind: ClusterBundle
 metadata:
   name: '1.9.7.testbundle-zork'

--- a/pkg/transformer/inline_test.go
+++ b/pkg/transformer/inline_test.go
@@ -22,11 +22,12 @@ import (
 	"context"
 	bpb "github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/apis/bundle/v1alpha1"
 	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/converter"
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/core"
 	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/find"
 )
 
 const bundleWithRefs = `
-apiVersion: 'bundle.k8s.io/v1alpha1'
+apiVersion: 'gke.io/k8s-cluster-bundle/v1alpha1'
 kind: ClusterBundle
 metadata:
   name: test-bundle
@@ -134,16 +135,16 @@ func TestInlineBundle(t *testing.T) {
 	if got := finder.NodeConfig("master").GetInitFile(); got != initScriptContents {
 		t.Errorf("Master init script: Got %q, but wanted %q.", got, initScriptContents)
 	}
-	if got := finder.ClusterComponentObject("kube-apiserver", "biffbam")[0].GetFields()["biff"].GetStringValue(); got != "bam" {
+	if got := finder.ClusterObjects("kube-apiserver", core.ObjectRef{Name: "biffbam"})[0].GetFields()["biff"].GetStringValue(); got != "bam" {
 		t.Errorf("Master kubelet config: Got %q, but wanted %q.", got, "bam")
 	}
-	if got := finder.ClusterComponentObject("kubelet-config", "foobar")[0].GetFields()["foo"].GetStringValue(); got != "bar" {
+	if got := finder.ClusterObjects("kubelet-config", core.ObjectRef{Name: "foobar"})[0].GetFields()["foo"].GetStringValue(); got != "bar" {
 		t.Errorf("Master kubelet config: Got %q, but wanted %q.", got, "bar")
 	}
 }
 
 const twoLayerBundle = `
-apiVersion: 'bundle.k8s.io/v1alpha1'
+apiVersion: 'gke.io/k8s-cluster-bundle/v1alpha1'
 kind: ClusterBundle
 metadata:
   name: test-bundle
@@ -177,7 +178,7 @@ func TestTwoLayerInline(t *testing.T) {
 	if got := finder.NodeConfig("master").GetInitFile(); got != initScriptContents {
 		t.Errorf("Master init script: Got %q, but wanted %q.", got, initScriptContents)
 	}
-	found := finder.ClusterComponentObject("kube-apiserver", "biffbam")
+	found := finder.ClusterObjects("kube-apiserver", core.ObjectRef{Name: "biffbam"})
 	comp := finder.ClusterComponent("kube-apiserver")
 	if len(found) == 0 {
 		t.Fatalf("could not find component %q and object %q in object %v", "kube-apiserver", "biffbam", comp)
@@ -199,14 +200,14 @@ func TestTwoLayerInline(t *testing.T) {
 	if len(found) == 0 {
 		t.Fatalf("could not find component %q and object %q in object %v", "kube-apiserver", "biffbam", comp)
 	}
-	found = finder.ClusterComponentObject("kube-apiserver", "biffbam")
+	found = finder.ClusterObjects("kube-apiserver", core.ObjectRef{Name: "biffbam"})
 	if len(found) != 0 {
 		t.Fatalf("found %v but did not expect to find anything", found)
 	}
 }
 
 const bundleWithMultidoc = `
-apiVersion: 'bundle.k8s.io/v1alpha1'
+apiVersion: 'gke.io/k8s-cluster-bundle/v1alpha1'
 kind: ClusterBundle
 metadata:
   name: test-bundle
@@ -240,10 +241,10 @@ func TestMultiDoc(t *testing.T) {
 		t.Fatalf("Error creating bundle finder: %v", err)
 	}
 
-	if got := finder.ClusterComponentObject("multidoc", "biffbam")[0].GetFields()["biff"].GetStringValue(); got != "bam" {
+	if got := finder.ClusterObjects("multidoc", core.ObjectRef{Name: "biffbam"})[0].GetFields()["biff"].GetStringValue(); got != "bam" {
 		t.Errorf("multidoc object: Got %q, but wanted %q.", got, "bam")
 	}
-	if got := finder.ClusterComponentObject("multidoc", "foobar")[0].GetFields()["foo"].GetStringValue(); got != "bar" {
+	if got := finder.ClusterObjects("multidoc", core.ObjectRef{Name: "foobar"})[0].GetFields()["foo"].GetStringValue(); got != "bar" {
 		t.Errorf("multidoc object: Got %q, but wanted %q.", got, "bar")
 	}
 }

--- a/pkg/validation/validate_bundle.go
+++ b/pkg/validation/validate_bundle.go
@@ -79,7 +79,7 @@ func (b *BundleValidator) validateClusterComponentNames() []error {
 func (b *BundleValidator) validateClusterObjNames() []error {
 	var errs []error
 	// Map to catch duplicate objects.
-	compObjects := make(map[core.ObjectReference]bool)
+	compObjects := make(map[core.ObjectRef]bool)
 	for _, ca := range b.Bundle.GetSpec().GetComponents() {
 		compName := ca.GetMetadata().GetName()
 		for _, obj := range ca.GetClusterObjects() {

--- a/pkg/validation/validate_bundle_test.go
+++ b/pkg/validation/validate_bundle_test.go
@@ -30,7 +30,7 @@ func TestValidateBundle(t *testing.T) {
 	}{
 		{
 			desc: "success",
-			bundle: `apiVersion: 'bundle.k8s.io/v1alpha1'
+			bundle: `apiVersion: 'gke.io/k8s-cluster-bundle/v1alpha1'
 kind: ClusterBundle
 metadata:
   name: '1.9.7.testbundle-zork'`,
@@ -39,7 +39,7 @@ metadata:
 
 		{
 			desc: "fail: duplicate node config key",
-			bundle: `apiVersion: 'bundle.k8s.io/v1alpha1'
+			bundle: `apiVersion: 'gke.io/k8s-cluster-bundle/v1alpha1'
 kind: ClusterBundle
 metadata:
   name: '1.9.7.testbundle-zork'
@@ -54,7 +54,7 @@ spec:
 
 		{
 			desc: "fail: duplicate cluster component key",
-			bundle: `apiVersion: 'bundle.k8s.io/v1alpha1'
+			bundle: `apiVersion: 'gke.io/k8s-cluster-bundle/v1alpha1'
 kind: ClusterBundle
 metadata:
   name: '1.9.7.testbundle-zork'
@@ -69,7 +69,7 @@ spec:
 
 		{
 			desc: "fail: api version on cluster obj",
-			bundle: `apiVersion: 'bundle.k8s.io/v1alpha1'
+			bundle: `apiVersion: 'gke.io/k8s-cluster-bundle/v1alpha1'
 kind: ClusterBundle
 metadata:
   name: '1.9.7.testbundle-zork'
@@ -86,7 +86,7 @@ spec:
 
 		{
 			desc: "fail: no kind on cluster obj",
-			bundle: `apiVersion: 'bundle.k8s.io/v1alpha1'
+			bundle: `apiVersion: 'gke.io/k8s-cluster-bundle/v1alpha1'
 kind: ClusterBundle
 metadata:
   name: '1.9.7.testbundle-zork'
@@ -103,7 +103,7 @@ spec:
 
 		{
 			desc: "fail: duplicate object ref",
-			bundle: `apiVersion: 'bundle.k8s.io/v1alpha1'
+			bundle: `apiVersion: 'gke.io/k8s-cluster-bundle/v1alpha1'
 kind: ClusterBundle
 metadata:
   name: '1.9.7.testbundle-zork'


### PR DESCRIPTION
Before, it was only possible to look up objects based on name. Now, any
part of the object ref key can be provided.

Fixes https://github.com/GoogleCloudPlatform/k8s-cluster-bundle/issues/33