### PR TITLE
Add an AppVersion field to the ComponentSpec.

### DIFF
--- a/pkg/apis/bundle/v1alpha1/component_types.go
+++ b/pkg/apis/bundle/v1alpha1/component_types.go
@@ -31,7 +31,8 @@ type ComponentSetSpec struct {
 	// changes should indicate breaking changes, minor-versions should indicate
 	// backwards compatible features, and patch changes should indicate backwords
 	// compatible. If there are any changes to the bundle, then the version
-	// string must be incremented.
+	// string must be incremented. As such, the version should not be tied to the
+	// version of the container images.
 	Version string `json:"version,omitempty"`
 
 	// Components are references to component objects that make up the component
@@ -84,6 +85,17 @@ type ComponentPackageSpec struct {
 	// patch changes should indicate backwards compatible. If there are any
 	// changes to the component, then the version string must be incremented.
 	Version string `json:"version,omitempty"`
+
+	// AppVersion is an optional SemVer versions string that should have the form
+	// X.Y or X.Y.Z (Major.Minor.Patch), which indicates the version of the
+	// application provided by the component. The AppVersion will frequently be
+	// the version of the container image and need not be updated when the
+	// Version field is updated.
+	//
+	// For example, for an etcd component, the version field might be something
+	// like 10.9.8, but the app version might be something like 3.3.10,
+	// representing the version of Etcd.
+	AppVersion string `json:"appVersion,omitempty"`
 
 	// Structured Kubenetes objects that run as part of this app, whether on the
 	// master, on the nodes, or in some other fashio.  These Kubernetes objects

--- a/pkg/validate/validate_component_test.go
+++ b/pkg/validate/validate_component_test.go
@@ -57,6 +57,7 @@ components:
   spec:
     componentName: foo-comp
     version: 2.0.3
+    appVersion: 2.4.5
 `
 
 func TestValidateAll(t *testing.T) {
@@ -146,6 +147,48 @@ spec:
 
 		// Tests for Components
 		{
+			desc: "success",
+			set:  defaultComponentSetNoRefs,
+			components: `
+components:
+- apiVersion: 'bundle.gke.io/v1alpha1'
+  kind: ComponentPackage
+  metadata:
+    name: foo-comp-1.0.2
+  spec:
+    componentName: foo-comp
+    version: 2.10.1
+    appVersion: 3.10.1`,
+		},
+		{
+			desc: "success: X.Y app version",
+			set:  defaultComponentSetNoRefs,
+			components: `
+components:
+- apiVersion: 'bundle.gke.io/v1alpha1'
+  kind: ComponentPackage
+  metadata:
+    name: foo-comp-1.0.2
+  spec:
+    componentName: foo-comp
+    version: 2.10.1
+    appVersion: 3.10`,
+		},
+		{
+			desc: "success: X.Y.Z-blah app version",
+			set:  defaultComponentSetNoRefs,
+			components: `
+components:
+- apiVersion: 'bundle.gke.io/v1alpha1'
+  kind: ComponentPackage
+  metadata:
+    name: foo-comp-1.0.2
+  spec:
+    componentName: foo-comp
+    version: 2.10.1
+    appVersion: 3.10.32-blah.0`,
+		},
+		{
 			desc: "fail component: no kind",
 			set:  defaultComponentSet,
 			components: `
@@ -192,6 +235,21 @@ components:
   spec:
     componentName: foo-comp
     version: 2.010.1`,
+			errSubstring: "must be of the form X.Y.Z",
+		},
+		{
+			desc: "fail: component invalid X.Y.Z app version string ",
+			set:  defaultComponentSetNoRefs,
+			components: `
+components:
+- apiVersion: 'bundle.gke.io/v1alpha1'
+  kind: ComponentPackage
+  metadata:
+    name: foo-comp-1.0.2
+  spec:
+    componentName: foo-comp
+    version: 2.10.1,
+    appVersion: 2.010.1`,
 			errSubstring: "must be of the form X.Y.Z",
 		},
 		{


### PR DESCRIPTION
This PR adds AppVersion as a field to the component spec. Note that the
versioning is much less restrictive here than for the `version` field.
The app version will accept X.Y and X.Y.Z-blah.0 in addition to X.Y.Z

Note: This intentionally doesn't add requirements. I now see this more
as something that would live as a CRD in the component objects.