### PR TITLE
Add filename when return error in converter.FromFileName #119

### DIFF
--- a/pkg/converter/muxer.go
+++ b/pkg/converter/muxer.go
@@ -63,7 +63,7 @@ func FromFileName(fname string, contents []byte) *Muxer {
 		return FromJSON(contents)
 	default:
 		// This will be an error during conversion
-		return &Muxer{format: UnknownContent}
+		return &Muxer{format: UnknownContent + ContentType("file: "+fname)}
 	}
 }
 


### PR DESCRIPTION
#119 
When return error in converter.FromFileName , it returns UnknownContent with filename