### PR TITLE
Add bundlewrapper object for bundle I/O

### DIFF
--- a/pkg/converter/muxer.go
+++ b/pkg/converter/muxer.go
@@ -122,9 +122,27 @@ func (m *Muxer) ToBundle() (*bundle.Bundle, error) {
 	return d, nil
 }
 
+// ToBundleBuilder converts input data to the BundleBuilder type.
+func (m *Muxer) ToBundleBuilder() (*bundle.BundleBuilder, error) {
+	d := &bundle.BundleBuilder{}
+	if err := m.mux(d); err != nil {
+		return nil, err
+	}
+	return d, nil
+}
+
 // ToComponent converts input data to the Component type.
 func (m *Muxer) ToComponent() (*bundle.Component, error) {
 	d := &bundle.Component{}
+	if err := m.mux(d); err != nil {
+		return nil, err
+	}
+	return d, nil
+}
+
+// ToComponentBuilder converts input data to the ComponentBuilder type.
+func (m *Muxer) ToComponentBuilder() (*bundle.ComponentBuilder, error) {
+	d := &bundle.ComponentBuilder{}
 	if err := m.mux(d); err != nil {
 		return nil, err
 	}

--- a/pkg/testutil/BUILD.bazel
+++ b/pkg/testutil/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = [
+        "errors.go",
         "fake_reader_writer.go",
         "testutil.go",
     ],

--- a/pkg/testutil/errors.go
+++ b/pkg/testutil/errors.go
@@ -1,0 +1,31 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testutil
+
+import (
+	"strings"
+	"testing"
+)
+
+// CheckErrorCases checks error cases for tests
+func CheckErrorCases(err error, expErrSubstr string, t *testing.T) {
+	if err == nil && expErrSubstr != "" {
+		t.Fatalf("Got no error but expected error containing %q", expErrSubstr)
+	} else if err != nil && expErrSubstr == "" {
+		t.Fatalf("Got error %q but expected no error", err.Error())
+	} else if err != nil && !strings.Contains(err.Error(), expErrSubstr) {
+		t.Fatalf("Got error %q but expected it to contain %q", err.Error(), expErrSubstr)
+	}
+}

--- a/pkg/wrapper/BUILD.bazel
+++ b/pkg/wrapper/BUILD.bazel
@@ -1,0 +1,19 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["bundlewrapper.go"],
+    importpath = "github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/wrapper",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/apis/bundle/v1alpha1:go_default_library",
+        "//pkg/converter:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["bundlewrapper_test.go"],
+    embed = [":go_default_library"],
+    deps = ["//pkg/testutil:go_default_library"],
+)

--- a/pkg/wrapper/bundlewrapper.go
+++ b/pkg/wrapper/bundlewrapper.go
@@ -1,0 +1,150 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package wrapper provides a union type for expressing various different
+// bundle-types.
+package wrapper
+
+import (
+	"fmt"
+
+	bundle "github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/apis/bundle/v1alpha1"
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/converter"
+)
+
+// BundleWrapper represents one of several possible bundle types -- a union type.
+type BundleWrapper struct {
+	bundle    *bundle.Bundle
+	component *bundle.Component
+
+	bundleBuilder    *bundle.BundleBuilder
+	componentBuilder *bundle.ComponentBuilder
+}
+
+// FromRaw creates a BundleWrapper object from a byte source, by converting
+// based off of the Kind.
+func FromRaw(inFmt string, bytes []byte) (*BundleWrapper, error) {
+	if len(bytes) == 0 {
+		return nil, fmt.Errorf("in FromRaw, content was empty")
+	}
+	if inFmt == "" {
+		return nil, fmt.Errorf("in FromRaw, format was empty")
+	}
+
+	uns, err := converter.FromContentType(inFmt, bytes).ToUnstructured()
+	if err != nil {
+		return nil, err
+	}
+
+	kind := uns.GetKind()
+	switch kind {
+	case "BundleBuilder":
+		b, err := converter.FromContentType(inFmt, bytes).ToBundleBuilder()
+		if err != nil {
+			return nil, err
+		}
+		return FromBundleBuilder(b), nil
+	case "Bundle":
+		b, err := converter.FromContentType(inFmt, bytes).ToBundle()
+		if err != nil {
+			return nil, err
+		}
+		return FromBundle(b), nil
+	case "ComponentBuilder":
+		c, err := converter.FromContentType(inFmt, bytes).ToComponentBuilder()
+		if err != nil {
+			return nil, err
+		}
+		return FromComponentBuilder(c), nil
+	case "Component":
+		c, err := converter.FromContentType(inFmt, bytes).ToComponent()
+		if err != nil {
+			return nil, err
+		}
+		return FromComponent(c), nil
+	default:
+		return nil, fmt.Errorf("unrecognized bundle-kind %s for content %s", kind, string(bytes))
+	}
+}
+
+// FromBundle creates a BundleWrapper from a bundle object.
+func FromBundle(c *bundle.Bundle) *BundleWrapper {
+	return &BundleWrapper{bundle: c}
+}
+
+// FromComponent creates a BundleWrapper from a component object
+func FromComponent(c *bundle.Component) *BundleWrapper {
+	return &BundleWrapper{component: c}
+}
+
+// FromBundleBuilder creates a BundleWrapper from a bundle builder object.
+func FromBundleBuilder(c *bundle.BundleBuilder) *BundleWrapper {
+	return &BundleWrapper{bundleBuilder: c}
+}
+
+// FromComponentBuilder creates a BundleWrapper from a component builder object
+func FromComponentBuilder(c *bundle.ComponentBuilder) *BundleWrapper {
+	return &BundleWrapper{componentBuilder: c}
+}
+
+// Bundle returns the wrapped bundle object.
+func (bw *BundleWrapper) Bundle() *bundle.Bundle { return bw.bundle }
+
+// Component returns the wrapped Component object.
+func (bw *BundleWrapper) Component() *bundle.Component { return bw.component }
+
+// BundleBuilder returns the wrapped BundleBuilder object.
+func (bw *BundleWrapper) BundleBuilder() *bundle.BundleBuilder { return bw.bundleBuilder }
+
+// ComponentBuilder returns the wrapped ComponentBuilder object.
+func (bw *BundleWrapper) ComponentBuilder() *bundle.ComponentBuilder { return bw.componentBuilder }
+
+// Kind gets the type of the underlying object.
+func (bw *BundleWrapper) Kind() string {
+	if bw.Bundle() != nil {
+		return bw.Bundle().Kind
+	} else if bw.BundleBuilder() != nil {
+		return bw.BundleBuilder().Kind
+	} else if bw.Component() != nil {
+		return bw.Component().Kind
+	} else if bw.ComponentBuilder() != nil {
+		return bw.ComponentBuilder().Kind
+	}
+	return ""
+}
+
+// Object returns the wrapped object.
+func (bw *BundleWrapper) Object() interface{} {
+	if bw.Bundle() != nil {
+		return bw.Bundle()
+	} else if bw.BundleBuilder() != nil {
+		return bw.BundleBuilder()
+	} else if bw.Component() != nil {
+		return bw.Component()
+	} else if bw.ComponentBuilder() != nil {
+		return bw.ComponentBuilder()
+	}
+	return nil
+}
+
+// AllComponents returns all the components in the BundleWrapper, with the
+// assumption that only one of Bundle or Component is filled out.
+func (bw *BundleWrapper) AllComponents() []*bundle.Component {
+	if bw.bundle != nil {
+		return bw.bundle.Components
+	} else if bw.component != nil {
+		return []*bundle.Component{bw.component}
+	}
+	return nil
+}

--- a/pkg/wrapper/bundlewrapper_test.go
+++ b/pkg/wrapper/bundlewrapper_test.go
@@ -1,0 +1,112 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package wrapper provides a union type for expressing various different
+// bundle-types.
+package wrapper
+
+import (
+	"testing"
+
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/testutil"
+)
+
+func TestBundleWrapper_FromRaw(t *testing.T) {
+	testCases := []struct {
+		desc         string
+		content      string
+		contentType  string
+		expKind      string
+		expErrSubstr string
+	}{
+		{
+			desc: "success: bundle builder",
+			content: `
+apiVersion: bundle.gke.io/v1alpha1
+kind: BundleBuilder`,
+			contentType: "yaml",
+			expKind:     "BundleBuilder",
+		},
+		{
+			desc: "success: bundle",
+			content: `
+apiVersion: bundle.gke.io/v1alpha1
+kind: Bundle`,
+			contentType: "yaml",
+			expKind:     "Bundle",
+		},
+		{
+			desc: "success: component builder",
+			content: `
+apiVersion: bundle.gke.io/v1alpha1
+kind: ComponentBuilder`,
+			contentType: "yaml",
+			expKind:     "ComponentBuilder",
+		},
+		{
+			desc: "success: component",
+			content: `
+apiVersion: bundle.gke.io/v1alpha1
+kind: Component`,
+			contentType: "yaml",
+			expKind:     "Component",
+		},
+		{
+			desc: "success: bundle builder json",
+			content: `{
+"apiVersion": "bundle.gke.io/v1alpha1",
+"kind": "BundleBuilder"
+}`,
+			contentType: "json",
+			expKind:     "BundleBuilder",
+		},
+
+		// errors
+		{
+			desc:         "fail: empty content",
+			contentType:  "json",
+			expErrSubstr: "content was empty",
+		},
+		{
+			desc: "fail: empty content type",
+			content: `{
+"apiVersion": "bundle.gke.io/v1alpha1",
+"kind": "BundleBuilder"
+}`,
+			expErrSubstr: "format was empty",
+		},
+		{
+			desc: "fail: unrecognized kind",
+			content: `{
+"apiVersion": "bundle.gke.io/v1alpha1",
+"kind": "BundleBlarg"
+}`,
+			contentType:  "json",
+			expErrSubstr: "unrecognized bundle-kind",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			bw, err := FromRaw(tc.contentType, []byte(tc.content))
+			testutil.CheckErrorCases(err, tc.expErrSubstr, t)
+			if err != nil {
+				return
+			}
+			if kind := bw.Kind(); tc.expKind != "" && kind != tc.expKind {
+				t.Errorf("Got kind %q, but expected kind to be %q", kind, tc.expKind)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The BundleWrapper object is a simple union type that's useful for doing
input/output of bundle objects. It contains some logic for ensuring that
only one of the various bundle objects is non-nil at a given time.

- Incremental progress on #116
- Depends on #129