### PR TITLE
Copy the inline code to pkg/build and rework to use Builder forms.

### DIFF
--- a/pkg/build/BUILD.bazel
+++ b/pkg/build/BUILD.bazel
@@ -1,0 +1,39 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "config_map_maker.go",
+        "doc.go",
+        "inline.go",
+    ],
+    importpath = "github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/build",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/apis/bundle/v1alpha1:go_default_library",
+        "//pkg/converter:go_default_library",
+        "//pkg/files:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "config_map_maker_test.go",
+        "inline_integration_test.go",
+        "inline_test.go",
+    ],
+    data = ["//examples:component_testdata"],
+    embed = [":go_default_library"],
+    deps = [
+        "//pkg/apis/bundle/v1alpha1:go_default_library",
+        "//pkg/converter:go_default_library",
+        "//pkg/files:go_default_library",
+        "//pkg/testutil:go_default_library",
+        "//pkg/validate:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",
+    ],
+)

--- a/pkg/build/config_map_maker.go
+++ b/pkg/build/config_map_maker.go
@@ -1,0 +1,67 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/converter"
+)
+
+type configMapMaker struct {
+	cfgMap *corev1.ConfigMap
+}
+
+// Make a new ConfigMap with a metdata.name.
+//
+// Note that metadata.name fields have restrictions and so passed-in names will
+// be sanitized.
+// https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+func newConfigMapMaker(name string) *configMapMaker {
+	sanitizedName := converter.SanitizeName(name)
+	c := &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ConfigMap",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        sanitizedName,
+			Annotations: make(map[string]string),
+		},
+		Data: make(map[string]string),
+	}
+	return &configMapMaker{c}
+}
+
+// AddData adds a data-key to the config map.
+func (m *configMapMaker) addData(key, value string) {
+	// ConfigMaps require that each key must consist of alphanumeric characters,
+	// '-', '_' or '.'.
+	sanitizedKey := converter.SanitizeName(key)
+	m.cfgMap.Data[sanitizedKey] = value
+}
+
+// toUnstructured converts the config map to an Unstructured type.
+func (m *configMapMaker) toUnstructured() (*unstructured.Unstructured, error) {
+	json, err := converter.FromObject(m.cfgMap).ToJSON()
+	if err != nil {
+		return nil, fmt.Errorf("error converting toUnstructured: %v", err)
+	}
+	return converter.FromJSON(json).ToUnstructured()
+}

--- a/pkg/build/config_map_maker_test.go
+++ b/pkg/build/config_map_maker_test.go
@@ -1,0 +1,58 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build
+
+import (
+	"testing"
+
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/converter"
+)
+
+func TestMakeConfigMap(t *testing.T) {
+	cfg := newConfigMapMaker("zork")
+	cfg.addData("foo", "bar")
+	cfg.addData("biff", "bam")
+
+	exp := `apiVersion: v1
+data:
+  biff: bam
+  foo: bar
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  name: zork
+`
+
+	out, err := cfg.toUnstructured()
+	if err != nil {
+		t.Fatalf("error converting config map to unstructured: %v", err)
+	}
+
+	if n := cfg.cfgMap.ObjectMeta.Name; n != "zork" {
+		t.Errorf("got name %s but expected name zork", n)
+	}
+
+	if val := cfg.cfgMap.Data["foo"]; val != "bar" {
+		t.Errorf("got val %s but expected bar", val)
+	}
+
+	s, err := converter.FromObject(out).ToYAML()
+	if err != nil {
+		t.Errorf("error converting config map to yaml: %v", err)
+	}
+	if string(s) != exp {
+		t.Errorf("Expected serialized yaml\n%s\n but got\n%s", string(s), exp)
+	}
+}

--- a/pkg/build/doc.go
+++ b/pkg/build/doc.go
@@ -12,20 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package testutil
-
-import (
-	"strings"
-	"testing"
-)
-
-// CheckErrorCases checks error cases for tests
-func CheckErrorCases(t *testing.T, err error, expErrSubstr string) {
-	if err == nil && expErrSubstr != "" {
-		t.Fatalf("Got no error but expected error containing %q", expErrSubstr)
-	} else if err != nil && expErrSubstr == "" {
-		t.Fatalf("Got error %q but expected no error", err.Error())
-	} else if err != nil && !strings.Contains(err.Error(), expErrSubstr) {
-		t.Fatalf("Got error %q but expected it to contain %q", err.Error(), expErrSubstr)
-	}
-}
+// Package build has functionality for building components, bundles, and
+// component sets from the builder types.
+package build

--- a/pkg/build/inline.go
+++ b/pkg/build/inline.go
@@ -1,0 +1,223 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"regexp"
+
+	bundle "github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/apis/bundle/v1alpha1"
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/converter"
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/files"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// Inliner inlines data files by reading them from the local or a remote
+// filesystem.
+type Inliner struct {
+	// Readers reads from the local filesystem.
+	Readers map[files.URLScheme]files.FileObjReader
+}
+
+// NewLocalInliner creates a new inliner that only knows how to read local
+// files from disk. If the data is stored on disk, the cwd should be the path
+// to the directory containing the data file on disk. Relative paths are not
+// supported.
+func NewLocalInliner(cwd string) *Inliner {
+	return NewInlinerWithScheme(
+		files.FileScheme,
+		&files.LocalFileObjReader{filepath.Dir(cwd), &files.LocalFileSystemReader{}},
+	)
+}
+
+// NewInlinerWithScheme creates a new inliner given a URL scheme.
+func NewInlinerWithScheme(scheme files.URLScheme, objReader files.FileObjReader) *Inliner {
+	rdrMap := map[files.URLScheme]files.FileObjReader{
+		scheme: objReader,
+	}
+	return &Inliner{
+		Readers: rdrMap,
+	}
+}
+
+// BundleFiles converts dereferences file-references in for bundle files.
+func (n *Inliner) BundleFiles(ctx context.Context, data *bundle.BundleBuilder) (*bundle.Bundle, error) {
+	var compbs []*bundle.ComponentBuilder
+	var comps []*bundle.Component
+	for _, f := range data.ComponentFiles {
+		contents, err := n.readFile(ctx, f)
+		if err != nil {
+			return nil, fmt.Errorf("error reading file %q: %v", f.URL, err)
+		}
+		uns, err := converter.FromFileName(f.URL, contents).ToUnstructured()
+		if err != nil {
+			return nil, fmt.Errorf("error converting file %q to Unstructured: %v", f.URL, err)
+		}
+
+		kind := uns.GetKind()
+		switch kind {
+		case "Component":
+			c, err := converter.FromFileName(f.URL, contents).ToComponent()
+			if err != nil {
+				return nil, fmt.Errorf("error converting file %q to a component: %v", f.URL, err)
+			}
+			comps = append(comps, c)
+		case "ComponentBuilder":
+			c, err := converter.FromFileName(f.URL, contents).ToComponentBuilder()
+			if err != nil {
+				return nil, fmt.Errorf("error converting file %q to a component builder: %v", f.URL, err)
+			}
+			compbs = append(compbs, c)
+		default:
+			return nil, fmt.Errorf("unsupported kind for component: %q; only supported kinds are Component and ComponentBuilder", kind)
+		}
+	}
+
+	inlComps, err := n.AllComponentFiles(ctx, compbs)
+	if err != nil {
+		return nil, err
+	}
+	comps = append(comps, inlComps...)
+
+	newBundle := &bundle.Bundle{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "bundle.gke.io/v1alpha1",
+			Kind:       "Bundle",
+		},
+		ObjectMeta: *data.ObjectMeta.DeepCopy(),
+		SetName:    data.SetName,
+		Version:    data.Version,
+		Components: comps,
+	}
+	return newBundle, nil
+}
+
+var onlyWhitespace = regexp.MustCompile(`^\s*$`)
+var multiDoc = regexp.MustCompile("---(\n|$)")
+
+// ComponentFiles reads file-references for component builder objects.
+// The returned components are copies with the file-references removed.
+func (n *Inliner) ComponentFiles(ctx context.Context, comp *bundle.ComponentBuilder) (*bundle.Component, error) {
+	name := comp.ComponentName
+	var newObjs []*unstructured.Unstructured
+	for _, cf := range comp.ObjectFiles {
+		contents, err := n.readFile(ctx, cf)
+		if err != nil {
+			return nil, fmt.Errorf("error reading file %v for component %q: %v", cf, name, err)
+		}
+		ext := filepath.Ext(cf.URL)
+		if ext == ".yaml" && multiDoc.Match(contents) {
+			splat := multiDoc.Split(string(contents), -1)
+			for i, s := range splat {
+				if onlyWhitespace.MatchString(s) {
+					continue
+				}
+				obj, err := converter.FromYAMLString(s).ToUnstructured()
+				if err != nil {
+					return nil, fmt.Errorf("error converting multi-doc object number %d for component %q in file %q", i, name, cf.URL)
+				}
+				annot := obj.GetAnnotations()
+				if annot == nil {
+					annot = make(map[string]string)
+				}
+				annot[string(bundle.InlineTypeIdentifier)] = string(bundle.KubeObjectInline)
+				obj.SetAnnotations(annot)
+				newObjs = append(newObjs, obj)
+			}
+		} else {
+			obj, err := converter.FromFileName(cf.URL, contents).ToUnstructured()
+			if err != nil {
+				return nil, fmt.Errorf("error converting object to unstructured for component %q in file %q", name, cf.URL)
+			}
+			annot := obj.GetAnnotations()
+			if annot == nil {
+				annot = make(map[string]string)
+			}
+			annot[string(bundle.InlineTypeIdentifier)] = string(bundle.KubeObjectInline)
+			obj.SetAnnotations(annot)
+			newObjs = append(newObjs, obj)
+		}
+	}
+
+	for _, fg := range comp.RawTextFiles {
+		fgName := fg.Name
+		if fgName == "" {
+			return nil, fmt.Errorf("error reading raw text file group object for component %q; name was empty ", name)
+		}
+		m := newConfigMapMaker(fgName)
+		for _, cf := range fg.Files {
+			text, err := n.readFile(ctx, cf)
+			if err != nil {
+				return nil, fmt.Errorf("error reading raw text file for component %q: %v", name, err)
+			}
+			dataName := filepath.Base(cf.URL)
+			m.addData(dataName, string(text))
+		}
+		m.cfgMap.ObjectMeta.Annotations[string(bundle.InlineTypeIdentifier)] = string(bundle.RawStringInline)
+		uns, err := m.toUnstructured()
+		if err != nil {
+			return nil, fmt.Errorf("error converting text object to unstructured for component %q and file group %q: %v", name, fgName, err)
+		}
+		newObjs = append(newObjs, uns)
+	}
+
+	newComp := &bundle.Component{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "bundle.gke.io/v1alpha1",
+			Kind:       "Component",
+		},
+		ObjectMeta: *comp.ObjectMeta.DeepCopy(),
+		Spec: bundle.ComponentSpec{
+			ComponentName: comp.ComponentName,
+			Version:       comp.Version,
+			AppVersion:    comp.AppVersion,
+			Objects:       newObjs,
+		},
+	}
+	return newComp, nil
+}
+
+// AllComponentFiles is a convenience method for inlining multiple component files.
+func (n *Inliner) AllComponentFiles(ctx context.Context, cbs []*bundle.ComponentBuilder) ([]*bundle.Component, error) {
+	var out []*bundle.Component
+	for _, cb := range cbs {
+		newc, err := n.ComponentFiles(ctx, cb)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, newc)
+	}
+	return out, nil
+}
+
+// readFile from either a local or remote location.
+func (n *Inliner) readFile(ctx context.Context, file bundle.File) ([]byte, error) {
+	parsed, err := file.ParsedURL()
+	if err != nil {
+		return nil, err
+	}
+	scheme := files.URLScheme(parsed.Scheme)
+	if scheme == files.EmptyScheme {
+		scheme = files.FileScheme
+	}
+	rdr, ok := n.Readers[scheme]
+	if !ok {
+		return nil, fmt.Errorf("could not find file reader for scheme %q for url %q", parsed.Scheme, file.URL)
+	}
+	return rdr.ReadFileObj(ctx, file)
+}

--- a/pkg/build/inline_integration_test.go
+++ b/pkg/build/inline_integration_test.go
@@ -1,0 +1,64 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build
+
+import (
+	"context"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/converter"
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/testutil"
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/validate"
+)
+
+func TestRealisticDataParseAndInline(t *testing.T) {
+	// TODO(kashomon): Re-enable this test once the examples have been converted.
+	t.Skipf("Test skipped: re-add when examples have been converted to bundle-building")
+
+	ctx := context.Background()
+	b, err := testutil.ReadData("../../", "examples/cluster/bundle-builder-example.yaml")
+	if err != nil {
+		t.Fatalf("Error reading file %v", err)
+	}
+
+	dataFiles, err := converter.FromYAML(b).ToBundleBuilder()
+	if err != nil {
+		t.Fatalf("error converting data: %v", err)
+	}
+
+	if l := len(dataFiles.ComponentFiles); l == 0 {
+		t.Fatalf("found zero files, but expected some")
+	}
+
+	pathPrefix := testutil.TestPathPrefix("../../", "examples/cluster/bundle-builder-example.yaml")
+	inliner := NewLocalInliner(pathPrefix)
+
+	moreInlined, err := inliner.BundleFiles(ctx, dataFiles)
+	if err != nil {
+		t.Fatalf("Error calling BundleFiles(): %v", err)
+	}
+
+	_, err = converter.FromObject(moreInlined).ToYAML()
+	if err != nil {
+		t.Fatalf("Error converting the inlined data back into YAML: %v", err)
+	}
+
+	// Ensure it validates
+	if errs := validate.AllComponents(moreInlined.Components); len(errs) > 0 {
+		for _, e := range errs {
+			t.Errorf("Errors in validaton: %q", e.Error())
+		}
+	}
+}

--- a/pkg/build/inline_test.go
+++ b/pkg/build/inline_test.go
@@ -1,0 +1,500 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	bundle "github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/apis/bundle/v1alpha1"
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/converter"
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/files"
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/testutil"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+type fakeLocalReader struct {
+	files map[string][]byte
+}
+
+func (f *fakeLocalReader) ReadFileObj(_ context.Context, file bundle.File) ([]byte, error) {
+	url := file.URL
+	if strings.HasPrefix(url, "file://") {
+		url = strings.TrimPrefix(url, "file://")
+	}
+	fi, ok := f.files[url]
+	if !ok {
+		return nil, fmt.Errorf("unexpected file path %q", file.URL)
+	}
+	return fi, nil
+}
+
+const defaultBundle = `
+kind: BundleBuilder
+setName: foo-bundle
+version: 1.2.3
+componentFiles:
+- url: /path/to/apiserver-component.yaml`
+
+var kubeApiserverComponent = []byte(`
+kind: ComponentBuilder
+componentName: kube-apiserver
+version: 1.2.3
+objectFiles:
+- url: '/path/to/kube_apiserver.yaml'`)
+
+var kubeApiserver = []byte(`
+apiVersion: v1
+kind: Zork
+metadata:
+  name: biffbam
+biff: bam`)
+
+var defaultFiles = map[string][]byte{
+	"/path/to/apiserver-component.yaml": kubeApiserverComponent,
+	"/path/to/kube_apiserver.yaml":      kubeApiserver,
+}
+
+type bundleRef struct {
+	setName string
+	version string
+}
+
+type objCheck struct {
+	name     string
+	annotKey string
+	annotVal string
+
+	// For if the it's imported as raw text
+	cfgMap map[string]string
+}
+
+type compRef struct {
+	ref bundle.ComponentReference
+	obj []objCheck
+}
+
+func TestInlineBundleFiles(t *testing.T) {
+	ctx := context.Background()
+
+	testCases := []struct {
+		desc         string
+		data         string
+		files        map[string][]byte
+		expErrSubstr string
+		expBun       bundleRef
+		expComps     []compRef
+	}{
+		{
+			desc:   "success: inline basic bundle",
+			data:   defaultBundle,
+			files:  defaultFiles,
+			expBun: bundleRef{setName: "foo-bundle", version: "1.2.3"},
+			expComps: []compRef{
+				{
+					ref: bundle.ComponentReference{
+						ComponentName: "kube-apiserver",
+						Version:       "1.2.3",
+					},
+					obj: []objCheck{
+						{
+							name:     "biffbam",
+							annotKey: string(bundle.InlineTypeIdentifier),
+							annotVal: string(bundle.KubeObjectInline),
+						},
+					},
+				},
+			},
+		},
+
+		{
+			desc: "success: inline basic bundle + file prefix",
+			data: `
+kind: BundleBuilder
+setName: foo-bundle
+version: 1.2.3
+componentFiles:
+- url: file:///path/to/apiserver-component.yaml`,
+			files:  defaultFiles,
+			expBun: bundleRef{setName: "foo-bundle", version: "1.2.3"},
+			expComps: []compRef{
+				{
+					ref: bundle.ComponentReference{
+						ComponentName: "kube-apiserver",
+						Version:       "1.2.3",
+					},
+					obj: []objCheck{
+						{
+							name:     "biffbam",
+							annotKey: string(bundle.InlineTypeIdentifier),
+							annotVal: string(bundle.KubeObjectInline),
+						},
+					},
+				},
+			},
+		},
+
+		{
+			desc: "success: inline bundle with raw text",
+			data: `
+kind: BundleBuilder
+setName: foo-bundle
+version: 1.2.3
+componentFiles:
+- url: /path/to/raw-text-component.yaml`,
+			files: map[string][]byte{
+				"/path/to/raw-text.yaml":   []byte("foobar"),
+				"/path/to/rawer-text.yaml": []byte("boobar"),
+				"/path/to/raw-text-component.yaml": []byte(`
+kind: ComponentBuilder
+componentName: kube-apiserver
+version: 1.2.3
+rawTextFiles:
+- name: some-raw-text
+  files:
+  - url: '/path/to/raw-text.yaml'
+  - url: '/path/to/rawer-text.yaml'`),
+			},
+			expBun: bundleRef{setName: "foo-bundle", version: "1.2.3"},
+			expComps: []compRef{
+				{
+					ref: bundle.ComponentReference{
+						ComponentName: "kube-apiserver",
+						Version:       "1.2.3",
+					},
+					obj: []objCheck{
+						{
+							name:     "some-raw-text",
+							annotKey: string(bundle.InlineTypeIdentifier),
+							annotVal: string(bundle.RawStringInline),
+							cfgMap: map[string]string{
+								"raw-text.yaml":   "foobar",
+								"rawer-text.yaml": "boobar",
+							},
+						},
+					},
+				},
+			},
+		},
+
+		{
+			desc: "success: inline bundle with multi-doc",
+			data: `
+kind: BundleBuilder
+setName: multi-bundle
+version: 2.2.3
+componentFiles:
+- url: /path/to/multi-doc-component.yaml`,
+			files: map[string][]byte{
+				"/path/to/multi-doc-component.yaml": []byte(`kind: ComponentBuilder
+componentName: kube-multi
+version: 2.3.4
+objectFiles:
+- url: '/path/to/multi-doc-obj.yaml'`),
+				"/path/to/multi-doc-obj.yaml": []byte(`
+apiVersion: v1
+kind: Zork
+metadata:
+  name: foobar
+foo: bar
+---
+apiVersion: v1
+kind: Zork
+metadata:
+  name: biffbam
+biff: bam`),
+			},
+			expBun: bundleRef{setName: "multi-bundle", version: "2.2.3"},
+			expComps: []compRef{
+				{
+					ref: bundle.ComponentReference{
+						ComponentName: "kube-multi",
+						Version:       "2.3.4",
+					},
+					obj: []objCheck{
+						{
+							name:     "foobar",
+							annotKey: string(bundle.InlineTypeIdentifier),
+							annotVal: string(bundle.KubeObjectInline),
+						},
+						{
+							name:     "biffbam",
+							annotKey: string(bundle.InlineTypeIdentifier),
+							annotVal: string(bundle.KubeObjectInline),
+						},
+					},
+				},
+			},
+		},
+
+		{
+			desc: "success: inline bundle with component",
+			data: `
+kind: BundleBuilder
+setName: component-bundle
+version: 2.2.4
+componentFiles:
+- url: /path/to/foo-component.yaml`,
+			files: map[string][]byte{
+				"/path/to/foo-component.yaml": []byte(`kind: Component
+spec:
+  componentName: kube-inline
+  version: 2.3.4
+  objects:
+  - apiVersion: v1
+    kind: pod
+    metadata:
+      name: foo-comp`),
+			},
+			expBun: bundleRef{setName: "component-bundle", version: "2.2.4"},
+			expComps: []compRef{
+				{
+					ref: bundle.ComponentReference{
+						ComponentName: "kube-inline",
+						Version:       "2.3.4",
+					},
+					obj: []objCheck{
+						{
+							name: "foo-comp",
+						},
+					},
+				},
+			},
+		},
+
+		// Error cases
+		{
+			desc: "error: bad component type",
+			data: defaultBundle,
+			files: map[string][]byte{
+				"/path/to/apiserver-component.yaml": []byte(`
+kind: Zog
+componentName: kube-apiserver
+version: 1.2.3
+objectFiles:
+- url: '/path/to/kube_apiserver.yaml'`),
+			},
+			expErrSubstr: "unsupported kind",
+		},
+		{
+			desc:         "fail: can't read file",
+			data:         defaultBundle,
+			files:        make(map[string][]byte),
+			expErrSubstr: "error reading file",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			data, err := converter.FromYAMLString(tc.data).ToBundleBuilder()
+			if err != nil {
+				t.Fatalf("Error converting bundle: %v", err)
+			}
+
+			inliner := NewInlinerWithScheme(files.FileScheme, &fakeLocalReader{tc.files})
+			got, err := inliner.BundleFiles(ctx, data)
+			testutil.CheckErrorCases(t, err, tc.expErrSubstr)
+			if err != nil {
+				return
+			}
+
+			if got == nil {
+				t.Fatalf("Expected data to not be nil")
+			}
+
+			validateBundle(t, got, tc.expBun)
+			validateComponents(t, got.Components, tc.expComps)
+		})
+	}
+}
+
+// Some of the Component cases are tested via TestInlineBundleFiles above
+// (which calls InlineComponentFiles).
+
+func TestInlineComponentFiles(t *testing.T) {
+	ctx := context.Background()
+
+	testCases := []struct {
+		desc         string
+		data         []byte
+		files        map[string][]byte
+		expErrSubstr string
+		expComp      compRef
+	}{
+		{
+			desc:  "success: inline basic component",
+			data:  kubeApiserverComponent,
+			files: defaultFiles,
+			expComp: compRef{
+				ref: bundle.ComponentReference{
+					ComponentName: "kube-apiserver",
+					Version:       "1.2.3",
+				},
+				obj: []objCheck{
+					{
+						name:     "biffbam",
+						annotKey: string(bundle.InlineTypeIdentifier),
+						annotVal: string(bundle.KubeObjectInline),
+					},
+				},
+			},
+		},
+
+		// Error cases.
+		{
+			desc:         "fail: can't read file",
+			data:         kubeApiserverComponent,
+			files:        make(map[string][]byte),
+			expErrSubstr: "error reading file",
+		},
+		{
+			desc: "fail: can't read raw text file",
+			data: []byte(`
+kind: ComponentBuilder
+componentName: kube-apiserver
+version: 1.2.3
+rawTextFiles:
+- name: foo-group
+  files:
+  - url: '/path/to/raw-text.yaml'
+  - url: '/path/to/rawer-text.yaml'`),
+			files:        make(map[string][]byte),
+			expErrSubstr: "error reading raw text file for",
+		},
+		{
+			desc: "fail: can't read raw text file group: no name",
+			data: []byte(`
+kind: ComponentBuilder
+componentName: kube-apiserver
+version: 1.2.3
+rawTextFiles:
+- files:
+  - url: '/path/to/raw-text.yaml'
+  - url: '/path/to/rawer-text.yaml'`),
+			files:        make(map[string][]byte),
+			expErrSubstr: "error reading raw text file group",
+		},
+		{
+			desc: "fail: can't convert object to unstructured",
+			data: kubeApiserverComponent,
+			files: map[string][]byte{
+				"/path/to/kube_apiserver.yaml": []byte("blah"),
+			},
+			expErrSubstr: "error converting object to unstructured",
+		},
+		{
+			desc: "fail: can't converting multi-doc object to unstructured",
+			data: kubeApiserverComponent,
+			files: map[string][]byte{
+				"/path/to/kube_apiserver.yaml": []byte(`
+blah
+---
+blar
+`),
+			},
+			expErrSubstr: "error converting multi-doc object",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			data, err := converter.FromYAML(tc.data).ToComponentBuilder()
+			if err != nil {
+				t.Fatalf("Error converting component: %v", err)
+			}
+
+			inliner := NewInlinerWithScheme(files.FileScheme, &fakeLocalReader{tc.files})
+			got, err := inliner.ComponentFiles(ctx, data)
+			testutil.CheckErrorCases(t, err, tc.expErrSubstr)
+			if err != nil {
+				return
+			}
+
+			if got == nil {
+				t.Fatalf("Expected data to not be nil")
+			}
+
+			validateComponents(t, []*bundle.Component{got}, []compRef{tc.expComp})
+		})
+	}
+}
+
+func validateBundle(t *testing.T, got *bundle.Bundle, expBun bundleRef) {
+	strbun, err := converter.FromObject(got).ToYAML()
+	if err != nil {
+		t.Fatalf("Error converting bundle back to YAML: %v", err)
+	}
+	if got.Kind != "Bundle" {
+		t.Errorf("After inlining bundle, got kind %q, but expected \"Bundle\". Output\n%s", got.Kind, strbun)
+	}
+	if expBun.setName != "" && expBun.setName != got.SetName {
+		t.Errorf("After inlining bundle, got SetName %q, expected %q. Output\n%s", got.SetName, expBun.setName, strbun)
+	}
+	if expBun.version != "" && expBun.version != got.Version {
+		t.Errorf("After inlining bundle, got Version %q, expected %q. Output\n%s", got.Version, expBun.setName, strbun)
+	}
+}
+
+func validateComponents(t *testing.T, comp []*bundle.Component, expComps []compRef) {
+	gotCompRefSet := make(map[bundle.ComponentReference]*bundle.Component)
+	var gotCompRefs []bundle.ComponentReference
+	for _, c := range comp {
+		gotCompRefSet[c.ComponentReference()] = c
+		gotCompRefs = append(gotCompRefs, c.ComponentReference())
+	}
+
+	// Compare the component contents
+	for _, ec := range expComps {
+		ref := ec.ref
+
+		comp, ok := gotCompRefSet[ref]
+		if !ok {
+			t.Errorf("got components %v, it did not contain expected component %v", gotCompRefs, ref)
+		}
+		if comp == nil {
+			t.Fatalf("got nil component for ref: %v", ref)
+		}
+
+		// Compare the object data
+		gotObjs := make(map[string]*unstructured.Unstructured)
+		for _, obj := range comp.Spec.Objects {
+			gotObjs[obj.GetName()] = obj
+		}
+		for _, o := range ec.obj {
+			obj := gotObjs[o.name]
+			if obj == nil {
+				t.Errorf("got objs %v, but object with name name %q.", gotObjs, o.name)
+			}
+			an := obj.GetAnnotations()
+			if an[o.annotKey] != o.annotVal {
+				t.Errorf("for obj %q, got annotation %q for key %q, but expected %q", o.name, an[o.annotKey], o.annotKey, o.annotVal)
+			}
+
+			// Check the config map contents.
+			for expkey, expval := range o.cfgMap {
+				dataObj := obj.Object["data"]
+				dataMap, ok := dataObj.(map[string]interface{})
+				if !ok {
+					t.Fatalf("Expected data to be a map of string to interface for comp %v in object %q", ref, obj.GetName())
+				}
+				val, ok := dataMap[expkey].(string)
+				if !ok || val != expval {
+					t.Fatalf("Could not find text object with key %q value %q for comp %v in object %q", expkey, expval, ref, obj.GetName())
+				}
+			}
+		}
+	}
+}

--- a/pkg/wrapper/bundlewrapper_test.go
+++ b/pkg/wrapper/bundlewrapper_test.go
@@ -100,7 +100,7 @@ kind: Component`,
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
 			bw, err := FromRaw(tc.contentType, []byte(tc.content))
-			testutil.CheckErrorCases(err, tc.expErrSubstr, t)
+			testutil.CheckErrorCases(t, err, tc.expErrSubstr)
 			if err != nil {
 				return
 			}


### PR DESCRIPTION
This PR reworks the inlining code in the following ways:

- Move to pkg/build, to set up for more building functionality.
- Remove relative path rewriting. The files must now all have absolute paths.
- Use the BundleBuilder/ComponentBuilder types, which get inlined to Bundle, Component types.
- Rewrite the tests from scratch to use a table-driven approach.

This was split out from #125
And is incremental progress on #116

Note: This has the downside of duplicating code between here and the
`pkg/inline` directory and also making the diffs / blame less clear. But
I think it's a bit easier to do incrementally this way.