### PR TITLE
Add a command for patching.

### DIFF
--- a/examples/component/etcd-component.yaml
+++ b/examples/component/etcd-component.yaml
@@ -97,5 +97,17 @@ spec:
       kind: Pod
       metadata:
         namespace:
-          {{.Namespace}}
+          {{.namespace}}
+  - apiVersion: bundle.gke.io/v1alpha1
+    kind: PatchTemplate
+    metadata:
+      annotations:
+        bundle.gke.io/inline-type: kube-object
+        build-label-test: build-label-test
+    template: |
+      apiVersion: v1
+      kind: Pod
+      metadata:
+        annotations:
+          build-label: {{.buildLabel}}
   version: 30.0.2

--- a/examples/component/etcd-server.yaml
+++ b/examples/component/etcd-server.yaml
@@ -100,4 +100,4 @@ template: |
   kind: Pod
   metadata:
     namespace:
-      {{.Namespace}}
+      {{.namespace}}

--- a/examples/component/options.yaml
+++ b/examples/component/options.yaml
@@ -1,0 +1,3 @@
+# Options for applying to the component via patch-templates
+namespace: foo-namespace
+buildLabel: test-build

--- a/pkg/commands/BUILD.bazel
+++ b/pkg/commands/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//pkg/commands/filter:go_default_library",
         "//pkg/commands/find:go_default_library",
         "//pkg/commands/modify:go_default_library",
+        "//pkg/commands/patch:go_default_library",
         "//pkg/commands/validate:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",
     ],

--- a/pkg/commands/patch/BUILD.bazel
+++ b/pkg/commands/patch/BUILD.bazel
@@ -1,0 +1,22 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "add_commands.go",
+        "patch.go",
+    ],
+    importpath = "github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/commands/patch",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/apis/bundle/v1alpha1:go_default_library",
+        "//pkg/commands/cmdlib:go_default_library",
+        "//pkg/converter:go_default_library",
+        "//pkg/files:go_default_library",
+        "//pkg/filter:go_default_library",
+        "//pkg/options/patchtmpl:go_default_library",
+        "//pkg/wrapper:go_default_library",
+        "//vendor/github.com/golang/glog:go_default_library",
+        "//vendor/github.com/spf13/cobra:go_default_library",
+    ],
+)

--- a/pkg/commands/patch/add_commands.go
+++ b/pkg/commands/patch/add_commands.go
@@ -1,0 +1,45 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package patch
+
+import (
+	"context"
+
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/commands/cmdlib"
+	"github.com/spf13/cobra"
+)
+
+// AddCommandsTo adds commands to a root cobra command.
+func AddCommandsTo(ctx context.Context, root *cobra.Command) {
+	cmd := &cobra.Command{
+		Use:   "patch",
+		Short: "Apply patch templates to component objects",
+		Long: "Apply patch templates to component objects. " +
+			"Options are usually applied to the templates before application.",
+		Run: cmdlib.ContextAction(ctx, action),
+	}
+
+	// Optional flags
+
+	// While options-file is technically optional, it is usually provided to
+	// detemplatize the patch templates.
+	cmd.Flags().StringVarP(&opts.optionsFile, "options-file", "", "",
+		"File containing options to apply to patch templates")
+
+	cmd.Flags().StringVarP(&opts.patchAnnotations, "patch-annotations", "", "",
+		"Select a subset of patches to apply based on a list of annotations of the form \"key1,val1;key2,val2;\"")
+
+	root.AddCommand(cmd)
+}

--- a/pkg/commands/patch/patch.go
+++ b/pkg/commands/patch/patch.go
@@ -1,0 +1,119 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package patch
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	log "github.com/golang/glog"
+	"github.com/spf13/cobra"
+
+	bundle "github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/apis/bundle/v1alpha1"
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/commands/cmdlib"
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/converter"
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/files"
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/filter"
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/options/patchtmpl"
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/wrapper"
+)
+
+// options represents options flags for the filter command.
+type options struct {
+	// patchAnnotations selects a subset of patch templates to apply via annotations.
+	// Has the form "foo,bar;biff,baz".
+	patchAnnotations string
+
+	// optionsFile contains yaml or json structured data containing options to
+	// apply to PatchTemplates
+	optionsFile string
+}
+
+// opts is a global options instance for reference via the add commands.
+var opts = &options{}
+
+func action(ctx context.Context, cmd *cobra.Command, _ []string) {
+	gopt := cmdlib.GlobalOptionsValues.Copy()
+	rw := &files.LocalFileSystemReaderWriter{}
+	brw := cmdlib.NewBundleReaderWriter(
+		rw,
+		&cmdlib.RealStdioReaderWriter{})
+	if err := run(ctx, opts, brw, rw, gopt); err != nil {
+		log.Exit(err)
+	}
+}
+
+func run(ctx context.Context, o *options, brw cmdlib.BundleReaderWriter, rw files.FileReaderWriter, gopt *cmdlib.GlobalOptions) error {
+	bw, err := brw.ReadBundleData(ctx, gopt)
+	if err != nil {
+		return fmt.Errorf("error reading contents: %v", err)
+	}
+
+	optData := make(map[string]interface{})
+	if o.optionsFile != "" {
+		bytes, err := rw.ReadFile(ctx, o.optionsFile)
+		if err != nil {
+			return err
+		}
+		optData, err = converter.FromFileName(o.optionsFile, bytes).ToJSONMap()
+		if err != nil {
+			return err
+		}
+	}
+
+	fopts := &filter.Options{}
+	if o.patchAnnotations != "" {
+		// TODO(kashomon): make a helper for this in bundleio
+		m := make(map[string]string)
+		splat := strings.Split(o.patchAnnotations, ";")
+		for _, v := range splat {
+			kv := strings.Split(v, ",")
+			if len(kv) == 2 {
+				m[kv[0]] = kv[1]
+			}
+		}
+		fopts.Annotations = m
+	}
+
+	applier := patchtmpl.NewApplier(patchtmpl.DefaultPatcherScheme(), fopts)
+
+	switch bw.Kind() {
+	case "Component":
+		log.Info("Patching component")
+		comp, err := applier.ApplyOptions(bw.Component(), optData)
+		if err != nil {
+			return err
+		}
+		bw = wrapper.FromComponent(comp)
+	case "Bundle":
+		log.Info("Patching bundle")
+		bun := bw.Bundle()
+		var comps []*bundle.Component
+		for _, comp := range bun.Components {
+			comp, err := applier.ApplyOptions(comp, optData)
+			if err != nil {
+				return err
+			}
+			comps = append(comps, comp)
+		}
+		bun.Components = comps
+		bw = wrapper.FromBundle(bun)
+	default:
+		return fmt.Errorf("bundle kind %q not supported for patching.", bw.Kind())
+	}
+
+	return brw.WriteBundleData(ctx, bw, gopt)
+}

--- a/pkg/commands/root.go
+++ b/pkg/commands/root.go
@@ -23,6 +23,7 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/commands/filter"
 	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/commands/find"
 	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/commands/modify"
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/commands/patch"
 	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/commands/validate"
 	"github.com/spf13/cobra"
 )
@@ -51,10 +52,11 @@ func AddCommands(ctx context.Context, args []string) *cobra.Command {
 	rootCmd.PersistentFlags().BoolVarP(
 		&cmdlib.GlobalOptionsValues.Inline, "inline", "l", true, "Whether to inline files before processing")
 
+	build.AddCommandsTo(ctx, rootCmd)
 	filter.AddCommandsTo(ctx, rootCmd)
 	find.AddCommandsTo(ctx, rootCmd)
-	build.AddCommandsTo(ctx, rootCmd)
 	modify.AddCommandsTo(ctx, rootCmd)
+	patch.AddCommandsTo(ctx, rootCmd)
 	validate.AddCommandsTo(ctx, rootCmd)
 
 	// This is magic hackery I don't unherdstand but somehow this fixes

--- a/pkg/converter/muxer.go
+++ b/pkg/converter/muxer.go
@@ -58,7 +58,7 @@ func FromJSON(b []byte) *Muxer {
 func FromFileName(fname string, contents []byte) *Muxer {
 	ext := filepath.Ext(fname)
 	switch ext {
-	case ".yaml":
+	case ".yaml", ".yml":
 		return FromYAML(contents)
 	case ".json":
 		return FromJSON(contents)
@@ -162,6 +162,15 @@ func (m *Muxer) ToComponentSet() (*bundle.ComponentSet, error) {
 func (m *Muxer) ToUnstructured() (*unstructured.Unstructured, error) {
 	d := &unstructured.Unstructured{}
 	if err := m.mux(d); err != nil {
+		return nil, err
+	}
+	return d, nil
+}
+
+// ToJSONMap converts from json/yaml data to a map of string-to-interface.
+func (m *Muxer) ToJSONMap() (map[string]interface{}, error) {
+	d := make(map[string]interface{})
+	if err := m.mux(&d); err != nil {
 		return nil, err
 	}
 	return d, nil

--- a/pkg/options/common.go
+++ b/pkg/options/common.go
@@ -15,9 +15,8 @@
 package options
 
 import (
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-
 	bundle "github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/apis/bundle/v1alpha1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 // ObjHandler is a function that can apply options to a Kubernetes object.

--- a/pkg/options/patchtmpl/patch.go
+++ b/pkg/options/patchtmpl/patch.go
@@ -70,6 +70,11 @@ type parsedPatch struct {
 	uns *unstructured.Unstructured
 }
 
+// String returns the string form of the parsed patch.
+func (p *parsedPatch) String() string {
+	return string(p.raw)
+}
+
 func (a *applier) makePatches(comp *bundle.Component, opts options.JSONOptions) ([]*parsedPatch, error) {
 	tfil := a.tmplFilter
 	if tfil == nil {
@@ -141,7 +146,6 @@ func objectApplier(scheme *PatcherScheme, patches []*parsedPatch) options.ObjHan
 		if len(objJSON) == 0 {
 			return nil, fmt.Errorf("converted object JSON was empty")
 		}
-		fmt.Errorf("obj: %s", objJSON)
 
 		deserializer := scheme.Codecs.UniversalDeserializer()
 		for _, pat := range patches {


### PR DESCRIPTION
This adds a simple command for patching.

tested with:

`go run cmd/bundlectl/main.go patch --input-file=examples/component/etcd-component.yaml --options-file=examples/component/options.yaml --patch-annotations=build-label-test,build-label-test`

and 

`go run cmd/bundlectl/main.go patch --input-file=examples/component/etcd-component.yaml --options-file=examples/component/options.yaml`