### PR TITLE
Generate the component name if it is not specified

### DIFF
--- a/pkg/build/BUILD.bazel
+++ b/pkg/build/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/validation:go_default_library",
     ],
 )
 

--- a/pkg/build/inline.go
+++ b/pkg/build/inline.go
@@ -186,7 +186,7 @@ func (n *Inliner) ComponentFiles(ctx context.Context, comp *bundle.ComponentBuil
 	}
 	errs := validation.IsDNS1123Subdomain(om.Name)
 	if len(errs) > 0 {
-		return nil, fmt.Errorf("metadata.Name %q is not a valid DNS 1123 label in component %q/%q: %v",
+		return nil, fmt.Errorf("metadata.Name %q is not a valid DNS 1123 subdomain in component %q/%q: %v",
 			om.Name, comp.ComponentName, comp.Version, errs)
 	}
 	newComp := &bundle.Component{

--- a/pkg/build/inline.go
+++ b/pkg/build/inline.go
@@ -111,7 +111,7 @@ func (n *Inliner) BundleFiles(ctx context.Context, data *bundle.BundleBuilder) (
 
 var onlyWhitespace = regexp.MustCompile(`^\s*$`)
 var multiDoc = regexp.MustCompile("---(\n|$)")
-var nonDNS = regexp.MustCompile(`[^-a-z0-9]`)
+var nonDNS = regexp.MustCompile(`[^-a-z0-9\.]`)
 
 // ComponentFiles reads file-references for component builder objects.
 // The returned components are copies with the file-references removed.
@@ -184,9 +184,10 @@ func (n *Inliner) ComponentFiles(ctx context.Context, comp *bundle.ComponentBuil
 		name := strings.ToLower(comp.ComponentName + `-` + comp.Version)
 		om.Name = nonDNS.ReplaceAllLiteralString(name, `-`)
 	}
-	errs := validation.IsDNS1123Label(om.Name)
+	errs := validation.IsDNS1123Subdomain(om.Name)
 	if len(errs) > 0 {
-		return nil, fmt.Errorf("component name %q is not a valid DNS 1123 label: %v", om.Name, errs)
+		return nil, fmt.Errorf("metadata.Name %q is not a valid DNS 1123 label in component %q/%q: %v",
+			om.Name, comp.ComponentName, comp.Version, errs)
 	}
 	newComp := &bundle.Component{
 		TypeMeta: metav1.TypeMeta{

--- a/pkg/build/inline_test.go
+++ b/pkg/build/inline_test.go
@@ -107,7 +107,7 @@ func TestInlineBundleFiles(t *testing.T) {
 			expBun: bundleRef{setName: "foo-bundle", version: "1.2.3"},
 			expComps: []compRef{
 				{
-					name: "kube-apiserver-1-2-3",
+					name: "kube-apiserver-1.2.3",
 					ref: bundle.ComponentReference{
 						ComponentName: "kube-apiserver",
 						Version:       "1.2.3",
@@ -135,7 +135,7 @@ componentFiles:
 			expBun: bundleRef{setName: "foo-bundle", version: "1.2.3"},
 			expComps: []compRef{
 				{
-					name: "kube-apiserver-1-2-3",
+					name: "kube-apiserver-1.2.3",
 					ref: bundle.ComponentReference{
 						ComponentName: "kube-apiserver",
 						Version:       "1.2.3",
@@ -175,7 +175,7 @@ rawTextFiles:
 			expBun: bundleRef{setName: "foo-bundle", version: "1.2.3"},
 			expComps: []compRef{
 				{
-					name: "kube-apiserver-1-2-3",
+					name: "kube-apiserver-1.2.3",
 					ref: bundle.ComponentReference{
 						ComponentName: "kube-apiserver",
 						Version:       "1.2.3",
@@ -225,7 +225,7 @@ biff: bam`),
 			expBun: bundleRef{setName: "multi-bundle", version: "2.2.3"},
 			expComps: []compRef{
 				{
-					name: "kube-multi-2-3-4",
+					name: "kube-multi-2.3.4",
 					ref: bundle.ComponentReference{
 						ComponentName: "kube-multi",
 						Version:       "2.3.4",
@@ -350,7 +350,7 @@ func TestInlineComponentFiles(t *testing.T) {
 			data:  kubeApiserverComponent,
 			files: defaultFiles,
 			expComp: compRef{
-				name: "kube-apiserver-1-2-3",
+				name: "kube-apiserver-1.2.3",
 				ref: bundle.ComponentReference{
 					ComponentName: "kube-apiserver",
 					Version:       "1.2.3",

--- a/pkg/build/inline_test.go
+++ b/pkg/build/inline_test.go
@@ -84,8 +84,9 @@ type objCheck struct {
 }
 
 type compRef struct {
-	ref bundle.ComponentReference
-	obj []objCheck
+	name string
+	ref  bundle.ComponentReference
+	obj  []objCheck
 }
 
 func TestInlineBundleFiles(t *testing.T) {
@@ -106,6 +107,7 @@ func TestInlineBundleFiles(t *testing.T) {
 			expBun: bundleRef{setName: "foo-bundle", version: "1.2.3"},
 			expComps: []compRef{
 				{
+					name: "kube-apiserver-1-2-3",
 					ref: bundle.ComponentReference{
 						ComponentName: "kube-apiserver",
 						Version:       "1.2.3",
@@ -133,6 +135,7 @@ componentFiles:
 			expBun: bundleRef{setName: "foo-bundle", version: "1.2.3"},
 			expComps: []compRef{
 				{
+					name: "kube-apiserver-1-2-3",
 					ref: bundle.ComponentReference{
 						ComponentName: "kube-apiserver",
 						Version:       "1.2.3",
@@ -172,6 +175,7 @@ rawTextFiles:
 			expBun: bundleRef{setName: "foo-bundle", version: "1.2.3"},
 			expComps: []compRef{
 				{
+					name: "kube-apiserver-1-2-3",
 					ref: bundle.ComponentReference{
 						ComponentName: "kube-apiserver",
 						Version:       "1.2.3",
@@ -221,6 +225,7 @@ biff: bam`),
 			expBun: bundleRef{setName: "multi-bundle", version: "2.2.3"},
 			expComps: []compRef{
 				{
+					name: "kube-multi-2-3-4",
 					ref: bundle.ComponentReference{
 						ComponentName: "kube-multi",
 						Version:       "2.3.4",
@@ -345,6 +350,7 @@ func TestInlineComponentFiles(t *testing.T) {
 			data:  kubeApiserverComponent,
 			files: defaultFiles,
 			expComp: compRef{
+				name: "kube-apiserver-1-2-3",
 				ref: bundle.ComponentReference{
 					ComponentName: "kube-apiserver",
 					Version:       "1.2.3",
@@ -413,6 +419,31 @@ blar
 			},
 			expErrSubstr: "error converting multi-doc object",
 		},
+		{
+			desc: "error: invalid specified name",
+			data: []byte(`
+kind: ComponentBuilder
+metadata:
+  name: this-
+componentName: kube-apiserver
+version: 1.2.3
+objectFiles:
+- url: '/path/to/kube_apiserver.yaml'`),
+			files:        defaultFiles,
+			expErrSubstr: "DNS-1123",
+		},
+		{
+			desc: "error: invalid generated name",
+			data: []byte(`
+kind: ComponentBuilder
+metadata:
+componentName: kube-apiserver
+version: 1.2.3-
+objectFiles:
+- url: '/path/to/kube_apiserver.yaml'`),
+			files:        defaultFiles,
+			expErrSubstr: "DNS-1123",
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
@@ -474,6 +505,10 @@ func validateComponents(t *testing.T, comp []*bundle.Component, expComps []compR
 		}
 		if comp == nil {
 			t.Fatalf("got nil component for ref: %v", ref)
+		}
+
+		if comp.GetName() != ec.name {
+			t.Errorf("got component meta.name %q, but expected %q", comp.GetName(), ec.name)
 		}
 
 		// Compare the object data


### PR DESCRIPTION
I want Components coming out of ComponentBuilder to be applied via kubectl. This generates the name if it doesn't exist.

Fixes: #142