### PR TITLE
Docs, examples cleanup for patches.

### DIFF
--- a/examples/component/README.md
+++ b/examples/component/README.md
@@ -9,8 +9,37 @@ The `etcd-component.yaml` was generated frome the `etcd-component-builder.yaml` 
 
 Patching can be done with:
 
-`go run ../../cmd/bundlectl/main.go patch --input-file=etcd-component.yaml --options-file=options.yaml`
+```sh
+go run ../../cmd/bundlectl/main.go patch \
+  --input-file=etcd-component.yaml \
+  --options-file=options.yaml
+```
 
 Alternatively, a subset of patches can be applied with:
 
-`go run ../../cmd/bundlectl/main.go patch --input-file=etcd-component.yaml --options-file=options.yaml --patch-annotations=build-label-experiment,test`
+```sh
+go run ../../cmd/bundlectl/main.go patch \
+  --input-file=etcd-component.yaml \
+  --options-file=options.yaml \
+  --patch-annotations=build-label-experiment,test
+```
+
+## Patch Templates
+
+Patch Templates are a way to customize a kubernetes file. Here is an example
+Patch Template:
+
+```yaml
+apiVersion: bundle.gke.io/v1alpha1
+kind: PatchTemplate
+template: |
+  apiVersion: v1
+  kind: Pod
+  metadata:
+    namespace:
+      {{.namespace}}
+```
+
+Patch Templates apply to objects that match the `apiVersion`, `kind`, and
+`metadata.name` specified in the `template`. Thus, these fields cannot be
+modified with PatchTemplates.

--- a/examples/component/etcd-component-builder.yaml
+++ b/examples/component/etcd-component-builder.yaml
@@ -18,3 +18,4 @@ componentName: etcd-component
 version: 30.0.2
 objectFiles:
 - url: /etcd-server.yaml
+- url: /patches.yaml

--- a/examples/component/etcd-server.yaml
+++ b/examples/component/etcd-server.yaml
@@ -78,24 +78,3 @@ spec:
   - hostPath:
       path: /etc/srv/kubernetes
     name: etc
----
-apiVersion: bundle.gke.io/v1alpha1
-kind: PatchTemplate
-template: |
-  apiVersion: v1
-  kind: Pod
-  metadata:
-    namespace:
-      {{.namespace}}
----
-apiVersion: bundle.gke.io/v1alpha1
-kind: PatchTemplate
-metadata:
-  annotations:
-    build-label-experiment: test
-template: |
-  apiVersion: v1
-  kind: Pod
-  metadata:
-    annotations:
-      build-label: {{.buildLabel}}

--- a/examples/component/patches.yaml
+++ b/examples/component/patches.yaml
@@ -1,0 +1,20 @@
+apiVersion: bundle.gke.io/v1alpha1
+kind: PatchTemplate
+template: |
+  apiVersion: v1
+  kind: Pod
+  metadata:
+    namespace:
+      {{.namespace}}
+---
+apiVersion: bundle.gke.io/v1alpha1
+kind: PatchTemplate
+metadata:
+  annotations:
+    build-label-experiment: test
+template: |
+  apiVersion: v1
+  kind: Pod
+  metadata:
+    annotations:
+      build-label: {{.buildLabel}}


### PR DESCRIPTION
This PR splits out patches into a separate YAML file. Additionally,
updated the README.md to discuss patches an how they are used.