### PR TITLE
Rename muxer/demuxer to decoder/encoder.

### DIFF
--- a/pkg/converter/BUILD.bazel
+++ b/pkg/converter/BUILD.bazel
@@ -4,9 +4,9 @@ go_library(
     name = "go_default_library",
     srcs = [
         "converter.go",
-        "demuxer.go",
+        "decoder.go",
+        "encoder.go",
         "exporter.go",
-        "muxer.go",
         "name.go",
         "unstructured.go",
     ],
@@ -25,9 +25,9 @@ go_test(
     srcs = [
         "converter_integration_test.go",
         "converter_test.go",
+        "decoder_test.go",
         "example_test.go",
         "exporter_test.go",
-        "muxer_test.go",
         "name_test.go",
     ],
     data = [

--- a/pkg/converter/decoder.go
+++ b/pkg/converter/decoder.go
@@ -27,35 +27,35 @@ import (
 	bundle "github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/apis/bundle/v1alpha1"
 )
 
-// FromYAMLString creates a Muxer instance from a YAML string.
-func FromYAMLString(s string) *Muxer {
+// FromYAMLString creates a Decoder instance from a YAML string.
+func FromYAMLString(s string) *Decoder {
 	return FromYAML([]byte(s))
 }
 
-// FromYAML creates a Muxer instance from a YAML byte array.
-func FromYAML(b []byte) *Muxer {
-	return &Muxer{
+// FromYAML creates a Decoder instance from a YAML byte array.
+func FromYAML(b []byte) *Decoder {
+	return &Decoder{
 		data:   b,
 		format: YAML,
 	}
 }
 
-// FromJSONString creates a Muxer instance from a JSON string.
-func FromJSONString(s string) *Muxer {
+// FromJSONString creates a Decoder instance from a JSON string.
+func FromJSONString(s string) *Decoder {
 	return FromJSON([]byte(s))
 }
 
-// FromJSON creates a Muxer instance from a JSON byte array.
-func FromJSON(b []byte) *Muxer {
-	return &Muxer{
+// FromJSON creates a Decoder instance from a JSON byte array.
+func FromJSON(b []byte) *Decoder {
+	return &Decoder{
 		data:   b,
 		format: YAML,
 	}
 }
 
-// FromFileName creates a Muxer instance by guessing the type based on the file
+// FromFileName creates a Decoder instance by guessing the type based on the file
 // extension.
-func FromFileName(fname string, contents []byte) *Muxer {
+func FromFileName(fname string, contents []byte) *Decoder {
 	ext := filepath.Ext(fname)
 	switch ext {
 	case ".yaml", ".yml":
@@ -64,35 +64,35 @@ func FromFileName(fname string, contents []byte) *Muxer {
 		return FromJSON(contents)
 	default:
 		// This will be an error during conversion
-		return &Muxer{format: UnknownContent}
+		return &Decoder{format: UnknownContent}
 	}
 }
 
 // FromContentType takes an explicit content type to use for creating a
-// conversion Muxer.
-func FromContentType(ctype string, contents []byte) *Muxer {
+// conversion Decoder.
+func FromContentType(ctype string, contents []byte) *Decoder {
 	ctype = strings.ToLower(ctype)
-	return &Muxer{format: ContentType(ctype), data: contents}
+	return &Decoder{format: ContentType(ctype), data: contents}
 }
 
-// Muxer converts from an object's serialized format to an actual instance of
-// the object. By default, the Muxer does not allow unknown fields.
-type Muxer struct {
+// Decoder converts from an object's serialized format to an actual instance of
+// the object. By default, the Decoder does not allow unknown fields.
+type Decoder struct {
 	data               []byte
 	format             ContentType
 	allowUnknownFields bool
 }
 
 // AllowUnknownFields indicates whether to allow unknown fields during decoding.
-func (m *Muxer) AllowUnknownFields(allow bool) *Muxer {
-	return &Muxer{
+func (m *Decoder) AllowUnknownFields(allow bool) *Decoder {
+	return &Decoder{
 		data:               m.data,
 		format:             m.format,
 		allowUnknownFields: allow,
 	}
 }
 
-func (m *Muxer) mux(f interface{}) error {
+func (m *Decoder) mux(f interface{}) error {
 	switch m.format {
 	case YAML:
 		var mod yaml.JSONOpt = func(d *json.Decoder) *json.Decoder {
@@ -114,7 +114,7 @@ func (m *Muxer) mux(f interface{}) error {
 }
 
 // ToBundle converts input data to the Bundle type.
-func (m *Muxer) ToBundle() (*bundle.Bundle, error) {
+func (m *Decoder) ToBundle() (*bundle.Bundle, error) {
 	d := &bundle.Bundle{}
 	if err := m.mux(d); err != nil {
 		return nil, err
@@ -123,7 +123,7 @@ func (m *Muxer) ToBundle() (*bundle.Bundle, error) {
 }
 
 // ToBundleBuilder converts input data to the BundleBuilder type.
-func (m *Muxer) ToBundleBuilder() (*bundle.BundleBuilder, error) {
+func (m *Decoder) ToBundleBuilder() (*bundle.BundleBuilder, error) {
 	d := &bundle.BundleBuilder{}
 	if err := m.mux(d); err != nil {
 		return nil, err
@@ -132,7 +132,7 @@ func (m *Muxer) ToBundleBuilder() (*bundle.BundleBuilder, error) {
 }
 
 // ToComponent converts input data to the Component type.
-func (m *Muxer) ToComponent() (*bundle.Component, error) {
+func (m *Decoder) ToComponent() (*bundle.Component, error) {
 	d := &bundle.Component{}
 	if err := m.mux(d); err != nil {
 		return nil, err
@@ -141,7 +141,7 @@ func (m *Muxer) ToComponent() (*bundle.Component, error) {
 }
 
 // ToComponentBuilder converts input data to the ComponentBuilder type.
-func (m *Muxer) ToComponentBuilder() (*bundle.ComponentBuilder, error) {
+func (m *Decoder) ToComponentBuilder() (*bundle.ComponentBuilder, error) {
 	d := &bundle.ComponentBuilder{}
 	if err := m.mux(d); err != nil {
 		return nil, err
@@ -150,7 +150,7 @@ func (m *Muxer) ToComponentBuilder() (*bundle.ComponentBuilder, error) {
 }
 
 // ToComponentSet converts input data to the ComponentSet type.
-func (m *Muxer) ToComponentSet() (*bundle.ComponentSet, error) {
+func (m *Decoder) ToComponentSet() (*bundle.ComponentSet, error) {
 	d := &bundle.ComponentSet{}
 	if err := m.mux(d); err != nil {
 		return nil, err
@@ -159,7 +159,7 @@ func (m *Muxer) ToComponentSet() (*bundle.ComponentSet, error) {
 }
 
 // ToUnstructured converts input data to the Unstructured type.
-func (m *Muxer) ToUnstructured() (*unstructured.Unstructured, error) {
+func (m *Decoder) ToUnstructured() (*unstructured.Unstructured, error) {
 	d := &unstructured.Unstructured{}
 	if err := m.mux(d); err != nil {
 		return nil, err
@@ -168,7 +168,7 @@ func (m *Muxer) ToUnstructured() (*unstructured.Unstructured, error) {
 }
 
 // ToJSONMap converts from json/yaml data to a map of string-to-interface.
-func (m *Muxer) ToJSONMap() (map[string]interface{}, error) {
+func (m *Decoder) ToJSONMap() (map[string]interface{}, error) {
 	d := make(map[string]interface{})
 	if err := m.mux(&d); err != nil {
 		return nil, err
@@ -178,6 +178,6 @@ func (m *Muxer) ToJSONMap() (map[string]interface{}, error) {
 
 // ToObject converts to an arbitrary object via standard YAML / JSON
 // serialization.
-func (m *Muxer) ToObject(obj interface{}) error {
+func (m *Decoder) ToObject(obj interface{}) error {
 	return m.mux(obj)
 }

--- a/pkg/converter/decoder_test.go
+++ b/pkg/converter/decoder_test.go
@@ -111,7 +111,7 @@ zorp: zip
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			m := &Muxer{
+			m := &Decoder{
 				data:               []byte(tc.data),
 				allowUnknownFields: tc.allowUnknownFields,
 				format:             tc.format,

--- a/pkg/converter/encoder.go
+++ b/pkg/converter/encoder.go
@@ -23,16 +23,16 @@ import (
 )
 
 // FromObject creates a converting demuxer from an object.
-func FromObject(obj interface{}) *Demuxer {
-	return &Demuxer{obj}
+func FromObject(obj interface{}) *Encoder {
+	return &Encoder{obj}
 }
 
-// Demuxer converts from an object to some serialized format for the object.
-type Demuxer struct {
+// Encoder converts from an object to some serialized format for the object.
+type Encoder struct {
 	obj interface{}
 }
 
-func (m *Demuxer) demux(format ContentType) ([]byte, error) {
+func (m *Encoder) demux(format ContentType) ([]byte, error) {
 	switch format {
 	case YAML:
 		return yaml.Marshal(m.obj)
@@ -44,29 +44,29 @@ func (m *Demuxer) demux(format ContentType) ([]byte, error) {
 }
 
 // ToYAML converts an object to YAML bytes slice
-func (m *Demuxer) ToYAML() ([]byte, error) {
+func (m *Encoder) ToYAML() ([]byte, error) {
 	return m.demux(YAML)
 }
 
 // ToYAMLString converts an object to YAML string
-func (m *Demuxer) ToYAMLString() (string, error) {
+func (m *Encoder) ToYAMLString() (string, error) {
 	yamlBytes, err := m.demux(YAML)
 	return string(yamlBytes[:]), err
 }
 
 // ToJSON converts an object to JSON bytes slice
-func (m *Demuxer) ToJSON() ([]byte, error) {
+func (m *Encoder) ToJSON() ([]byte, error) {
 	return m.demux(JSON)
 }
 
 // ToJSONString converts an object to JSON string
-func (m *Demuxer) ToJSONString() (string, error) {
+func (m *Encoder) ToJSONString() (string, error) {
 	jsonBytes, err := m.demux(JSON)
 	return string(jsonBytes[:]), err
 }
 
 // ToContentType converts to a custom content type.
-func (m *Demuxer) ToContentType(ctype string) ([]byte, error) {
+func (m *Encoder) ToContentType(ctype string) ([]byte, error) {
 	lower := strings.ToLower(ctype)
 	return m.demux(ContentType(lower))
 }


### PR DESCRIPTION
Decoder and Encoder are far more common terms and much easier to understand.