### PR TITLE
Add support for nested properties during patch template building.

### DIFF
--- a/pkg/build/BUILD.bazel
+++ b/pkg/build/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//pkg/wrapper:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/validation:go_default_library",

--- a/pkg/build/patchbuild.go
+++ b/pkg/build/patchbuild.go
@@ -149,15 +149,16 @@ func BuildAllPatchTemplates(bw *wrapper.BundleWrapper, fopts *filter.Options, op
 }
 
 // addParamDefaults is a hack to allow us to pass through runtime templates
-// variables. Looks at the properties in a schema.
-// It only works for templates that only have simple variable
-// expansions.
+// variables, which works by looking at the properties in the target schema in
+// a PatchTemplateBuilder. It only works for templates that only use simple
+// template variables.
 func addParamDefaults(prefix string, props map[string]apiextensions.JSONSchemaProps, op options.JSONOptions) error {
 	for k, val := range props {
 		tmplKey := prefix + "." + k
 
 		if val.Properties != nil {
-			// The schema indicates that the this key-value pair has an object substructure.
+			// The schema indicates that the this key-value pair has an object
+			// substructure, and so we have to recurse into this structure.
 			var nestedOpts options.JSONOptions
 			optVal, hasVal := op[k]
 			if hasVal && optVal != nil {

--- a/pkg/build/patchbuild.go
+++ b/pkg/build/patchbuild.go
@@ -26,6 +26,7 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/options/openapi"
 	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/wrapper"
 	log "github.com/golang/glog"
+	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -55,11 +56,10 @@ func BuildPatchTemplate(ptb *bundle.PatchTemplateBuilder, opts options.JSONOptio
 	// This is a hack to allow us to pass through runtime templates variables
 	// It is only one level-deep. TODO(jbelamaric): fix it to support nested schema
 	if ptb.TargetSchema != nil && ptb.TargetSchema.Properties != nil {
-		for k := range ptb.TargetSchema.Properties {
-			opts[k] = `{{.` + k + `}}`
-		}
+		addParamDefaults("", ptb.TargetSchema.Properties, opts)
 	}
 
+	tmpl = tmpl.Option("missingkey=error")
 	var buf bytes.Buffer
 	err = tmpl.Execute(&buf, opts)
 	if err != nil {
@@ -146,4 +146,36 @@ func BuildAllPatchTemplates(bw *wrapper.BundleWrapper, fopts *filter.Options, op
 	}
 
 	return bw, nil
+}
+
+// addParamDefaults is a hack to allow us to pass through runtime templates
+// variables. Looks at the properties in a schema.
+// It only works for templates that only have simple variable
+// expansions.
+func addParamDefaults(prefix string, props map[string]apiextensions.JSONSchemaProps, op options.JSONOptions) error {
+	for k, val := range props {
+		tmplKey := prefix + "." + k
+
+		if val.Properties != nil {
+			// The schema indicates that the this key-value pair has an object substructure.
+			var nestedOpts options.JSONOptions
+			optVal, hasVal := op[k]
+			if hasVal && optVal != nil {
+				nopt, ok := optVal.(map[string]interface{})
+				if !ok {
+					return fmt.Errorf("Option value with key %q was expected to be an object-type, but was %v", tmplKey, optVal)
+				}
+				nestedOpts = nopt
+			} else {
+				nestedOpts = make(options.JSONOptions)
+				op[k] = nestedOpts
+			}
+			// This property contains nested properties. Recurse into these
+			// properties and modify the prefix
+			addParamDefaults(tmplKey, val.Properties, nestedOpts)
+		} else {
+			op[k] = `{{` + tmplKey + `}}`
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
This PR recursively looks through the target schema and creates template-parameters based on the keys that it finds in the `properties`.