### PR TITLE
Encoder/decoder cleanups.

### DIFF
--- a/pkg/build/inline.go
+++ b/pkg/build/inline.go
@@ -68,7 +68,7 @@ func (n *Inliner) BundleFiles(ctx context.Context, data *bundle.BundleBuilder) (
 		}
 		uns, err := converter.FromFileName(f.URL, contents).ToUnstructured()
 		if err != nil {
-			return nil, fmt.Errorf("error converting file %q to Unstructured: %v", f.URL, err)
+			return nil, err
 		}
 
 		kind := uns.GetKind()
@@ -76,13 +76,13 @@ func (n *Inliner) BundleFiles(ctx context.Context, data *bundle.BundleBuilder) (
 		case "Component":
 			c, err := converter.FromFileName(f.URL, contents).ToComponent()
 			if err != nil {
-				return nil, fmt.Errorf("error converting file %q to a component: %v", f.URL, err)
+				return nil, err
 			}
 			comps = append(comps, c)
 		case "ComponentBuilder":
 			c, err := converter.FromFileName(f.URL, contents).ToComponentBuilder()
 			if err != nil {
-				return nil, fmt.Errorf("error converting file %q to a component builder: %v", f.URL, err)
+				return nil, err
 			}
 			compbs = append(compbs, c)
 		default:
@@ -132,7 +132,7 @@ func (n *Inliner) ComponentFiles(ctx context.Context, comp *bundle.ComponentBuil
 				}
 				obj, err := converter.FromYAMLString(s).ToUnstructured()
 				if err != nil {
-					return nil, fmt.Errorf("error converting multi-doc object number %d for component %q in file %q", i, name, cf.URL)
+					return nil, fmt.Errorf("converting multi-doc object number %d for component %q, %v", i, name, err)
 				}
 				annot := obj.GetAnnotations()
 				if annot == nil {
@@ -145,7 +145,7 @@ func (n *Inliner) ComponentFiles(ctx context.Context, comp *bundle.ComponentBuil
 		} else {
 			obj, err := converter.FromFileName(cf.URL, contents).ToUnstructured()
 			if err != nil {
-				return nil, fmt.Errorf("error converting object to unstructured for component %q in file %q", name, cf.URL)
+				return nil, fmt.Errorf("for component %q, %v", name, err)
 			}
 			annot := obj.GetAnnotations()
 			if annot == nil {
@@ -174,7 +174,7 @@ func (n *Inliner) ComponentFiles(ctx context.Context, comp *bundle.ComponentBuil
 		m.cfgMap.ObjectMeta.Annotations[string(bundle.InlineTypeIdentifier)] = string(bundle.RawStringInline)
 		uns, err := m.toUnstructured()
 		if err != nil {
-			return nil, fmt.Errorf("error converting text object to unstructured for component %q and file group %q: %v", name, fgName, err)
+			return nil, fmt.Errorf("for component %q and file group %q, %v", name, fgName, err)
 		}
 		newObjs = append(newObjs, uns)
 	}

--- a/pkg/build/inline_integration_test.go
+++ b/pkg/build/inline_integration_test.go
@@ -32,7 +32,7 @@ func TestRealisticDataParseAndInline_Bundle(t *testing.T) {
 
 	dataFiles, err := converter.FromYAML(b).ToBundleBuilder()
 	if err != nil {
-		t.Fatalf("error converting data: %v", err)
+		t.Fatal(err)
 	}
 
 	if l := len(dataFiles.ComponentFiles); l == 0 {
@@ -69,7 +69,7 @@ func TestRealisticDataParseAndInline_Component(t *testing.T) {
 
 	cb, err := converter.FromYAML(b).ToComponentBuilder()
 	if err != nil {
-		t.Fatalf("error converting data: %v", err)
+		t.Fatal(err)
 	}
 
 	if l := len(cb.ObjectFiles); l == 0 {

--- a/pkg/converter/converter_integration_test.go
+++ b/pkg/converter/converter_integration_test.go
@@ -28,7 +28,7 @@ func TestRealisticDataParse_BundleBuilder(t *testing.T) {
 
 	dataFiles, err := FromYAML(b).ToBundleBuilder()
 	if err != nil {
-		t.Fatalf("Error calling ToBundle(): %v", err)
+		t.Fatal(err)
 	}
 
 	if l := len(dataFiles.ComponentFiles); l == 0 {
@@ -44,7 +44,7 @@ func TestRealisticDataParse_ComponentSet(t *testing.T) {
 
 	cset, err := FromYAML(b).ToComponentSet()
 	if err != nil {
-		t.Fatalf("Error calling ToComponentSet(): %v", err)
+		t.Fatal(err)
 	}
 
 	if l := len(cset.Spec.Components); l == 0 {
@@ -60,7 +60,7 @@ func TestRealisticDataParse_ComponentBuilder(t *testing.T) {
 
 	comp, err := FromYAML(b).ToComponentBuilder()
 	if err != nil {
-		t.Fatalf("Error calling ToComponentBuilder(): %v", err)
+		t.Fatal(err)
 	}
 
 	if l := len(comp.ObjectFiles); l == 0 {
@@ -76,7 +76,7 @@ func TestRealisticDataParse_Component(t *testing.T) {
 
 	comp, err := FromYAML(b).ToComponent()
 	if err != nil {
-		t.Fatalf("Error calling ToComponentBuilder(): %v", err)
+		t.Fatal(err)
 	}
 
 	if l := len(comp.Spec.Objects); l == 0 {

--- a/pkg/converter/converter_test.go
+++ b/pkg/converter/converter_test.go
@@ -84,7 +84,7 @@ spec:
 func TestConvertUnstructured(t *testing.T) {
 	firstIttObj, err := FromYAMLString(reschedulerManifest).ToUnstructured()
 	if err != nil {
-		t.Fatalf("unexpected error parsing manifest: %v", err)
+		t.Fatal(err)
 	}
 	// Check if one of the original YAML keys are reachable and value match
 	apiversionCheck, ok := firstIttObj.Object["apiVersion"].(string)
@@ -105,6 +105,9 @@ func TestConvertUnstructured(t *testing.T) {
 	}
 	// Convert YAML to Object one more time
 	secondIttObj, err := FromYAMLString(str).ToUnstructured()
+	if err != nil {
+		t.Fatal(err)
+	}
 	apiversionCheck, ok = secondIttObj.Object["apiVersion"].(string)
 	if !ok || apiversionCheck != "v1" {
 		t.Fatalf("manifest apiVersion key doesn't match original one:expected=v1, got=%v", apiversionCheck)
@@ -114,7 +117,7 @@ func TestConvertUnstructured(t *testing.T) {
 func TestConvertBundle(t *testing.T) {
 	firstIttObj, err := FromYAMLString(testBundleManifest).ToBundle()
 	if err != nil {
-		t.Fatalf("unexpected error parsing manifest: %v", err)
+		t.Fatal(err)
 	}
 	// Check if one of the original YAML keys are reachable and value match
 	if firstIttObj.APIVersion != "bundle.gke.io/v1alpha1" {
@@ -134,6 +137,9 @@ func TestConvertBundle(t *testing.T) {
 	}
 	// Convert YAML to Object one more time
 	secondIttObj, err := FromYAMLString(str).ToBundle()
+	if err != nil {
+		t.Fatal(err)
+	}
 	if secondIttObj.APIVersion != "bundle.gke.io/v1alpha1" {
 		t.Fatalf("manifest apiVersion key doesn't match original one:expected=v1, got=%v", firstIttObj.APIVersion)
 	}
@@ -162,6 +168,9 @@ func TestConvertComponent(t *testing.T) {
 	}
 	// Convert YAML to Object one more time
 	secondIttObj, err := FromYAMLString(str).ToComponent()
+	if err != nil {
+		t.Fatal(err)
+	}
 	if secondIttObj.APIVersion != "bundle.gke.io/v1alpha1" {
 		t.Fatalf("manifest apiVersion key doesn't match original one:expected=v1, got=%v", secondIttObj.APIVersion)
 	}
@@ -185,6 +194,9 @@ func TestConverterFormatTypeInversions(t *testing.T) {
 		t.Fatalf("unexpected error serializing manifest: %v", err)
 	}
 	thirdIttObj, err := FromJSONString(jsonString).ToComponent()
+	if err != nil {
+		t.Fatal(err)
+	}
 	if secondIttObj.APIVersion != "bundle.gke.io/v1alpha1" {
 		t.Fatalf("manifest apiVersion key doesn't match original one:expected=v1, got=%v", thirdIttObj.APIVersion)
 	}

--- a/pkg/converter/encoder.go
+++ b/pkg/converter/encoder.go
@@ -22,7 +22,7 @@ import (
 	"github.com/ghodss/yaml"
 )
 
-// FromObject creates a converting demuxer from an object.
+// FromObject creates a converting encodeer from an object.
 func FromObject(obj interface{}) *Encoder {
 	return &Encoder{obj}
 }
@@ -32,7 +32,7 @@ type Encoder struct {
 	obj interface{}
 }
 
-func (m *Encoder) demux(format ContentType) ([]byte, error) {
+func (m *Encoder) encode(format ContentType) ([]byte, error) {
 	switch format {
 	case YAML:
 		return yaml.Marshal(m.obj)
@@ -45,28 +45,28 @@ func (m *Encoder) demux(format ContentType) ([]byte, error) {
 
 // ToYAML converts an object to YAML bytes slice
 func (m *Encoder) ToYAML() ([]byte, error) {
-	return m.demux(YAML)
+	return m.encode(YAML)
 }
 
 // ToYAMLString converts an object to YAML string
 func (m *Encoder) ToYAMLString() (string, error) {
-	yamlBytes, err := m.demux(YAML)
+	yamlBytes, err := m.encode(YAML)
 	return string(yamlBytes[:]), err
 }
 
 // ToJSON converts an object to JSON bytes slice
 func (m *Encoder) ToJSON() ([]byte, error) {
-	return m.demux(JSON)
+	return m.encode(JSON)
 }
 
 // ToJSONString converts an object to JSON string
 func (m *Encoder) ToJSONString() (string, error) {
-	jsonBytes, err := m.demux(JSON)
+	jsonBytes, err := m.encode(JSON)
 	return string(jsonBytes[:]), err
 }
 
 // ToContentType converts to a custom content type.
 func (m *Encoder) ToContentType(ctype string) ([]byte, error) {
 	lower := strings.ToLower(ctype)
-	return m.demux(ContentType(lower))
+	return m.encode(ContentType(lower))
 }

--- a/pkg/converter/example_test.go
+++ b/pkg/converter/example_test.go
@@ -32,7 +32,7 @@ components:
 func TestDataParse(t *testing.T) {
 	data, err := FromYAMLString(componentDataExample).ToBundle()
 	if err != nil {
-		t.Fatalf("Error parsing bundle: %v", err)
+		t.Fatal(err)
 	}
 
 	if l := len(data.Components); l == 0 {

--- a/pkg/converter/exporter_test.go
+++ b/pkg/converter/exporter_test.go
@@ -40,7 +40,7 @@ func TestExporterMulti(t *testing.T) {
 	for _, o := range objForExport {
 		un, err := FromYAMLString(o).ToUnstructured()
 		if err != nil {
-			t.Fatalf("Failed to parse yaml:%v \n%s", err, o)
+			t.Fatal(err)
 		}
 		obj = append(obj, un)
 	}
@@ -60,7 +60,7 @@ func TestExporterSingle(t *testing.T) {
 	for _, o := range objForExport {
 		un, err := FromYAMLString(o).ToUnstructured()
 		if err != nil {
-			t.Fatalf("Failed to parse yaml:%v \n%s", err, o)
+			t.Fatal(err)
 		}
 		obj = append(obj, un)
 	}

--- a/pkg/filter/filter_test.go
+++ b/pkg/filter/filter_test.go
@@ -195,7 +195,7 @@ func TestFilterObjects(t *testing.T) {
 
 	data, err := converter.FromYAMLString(example).ToBundle()
 	if err != nil {
-		t.Fatalf("error converting data: %v", err)
+		t.Fatal(err)
 	}
 	for _, tc := range testcases {
 		t.Run(tc.desc, func(t *testing.T) {
@@ -366,7 +366,7 @@ func TestFilterComponents(t *testing.T) {
 
 	data, err := converter.FromYAMLString(componentExample).ToBundle()
 	if err != nil {
-		t.Fatalf("error converting bundle: %v", err)
+		t.Fatal(err)
 	}
 	for _, tc := range testcases {
 		t.Run(tc.desc, func(t *testing.T) {

--- a/pkg/find/finder_test.go
+++ b/pkg/find/finder_test.go
@@ -51,7 +51,7 @@ components:
 func TestBundleFinder(t *testing.T) {
 	b, err := converter.FromYAMLString(validComponentExample).ToBundle()
 	if err != nil {
-		t.Fatalf("error converting bundle: %v", err)
+		t.Fatal(err)
 	}
 	finder := NewComponentFinder(b.Components)
 	if err != nil {
@@ -145,7 +145,7 @@ spec:
 func TestComponentFinder_PartialLookup(t *testing.T) {
 	c, err := converter.FromYAMLString(validComponent).ToComponent()
 	if err != nil {
-		t.Fatalf("error converting componente: %v", err)
+		t.Fatal(err)
 	}
 	finder := NewObjectFinder(c)
 

--- a/pkg/find/images_test.go
+++ b/pkg/find/images_test.go
@@ -56,7 +56,7 @@ spec:
 func TestImageFinder_Found(t *testing.T) {
 	s, err := converter.FromYAMLString(schedulerExample).ToUnstructured()
 	if err != nil {
-		t.Fatalf("error converting obj: %v", err)
+		t.Fatal(err)
 	}
 	key := bundle.ComponentReference{"foo", "bar"}
 
@@ -108,7 +108,7 @@ spec:
 func TestImageFinder_NotFound(t *testing.T) {
 	s, err := converter.FromYAMLString(kubeDNSServiceExample).ToUnstructured()
 	if err != nil {
-		t.Fatalf("error converting obj: %v", err)
+		t.Fatal(err)
 	}
 	key := bundle.ComponentReference{"foo", "biff"}
 	f := ImageFinder{}
@@ -140,7 +140,7 @@ spec:
 func TestImageFinder_MultipleImages(t *testing.T) {
 	s, err := converter.FromYAMLString(loggerExample).ToUnstructured()
 	if err != nil {
-		t.Fatalf("error converting obj: %v", err)
+		t.Fatal(err)
 	}
 	key := bundle.ComponentReference{"gloo", "logger"}
 	expkey := core.ClusterObjectKey{
@@ -220,7 +220,7 @@ components:
 func TestImageFinder_Bundle(t *testing.T) {
 	s, err := converter.FromYAMLString(componentsExample).ToBundle()
 	if err != nil {
-		t.Fatalf("error converting data: %v", err)
+		t.Fatal(err)
 	}
 
 	found := NewImageFinder(s.Components).AllContainerImages()
@@ -292,7 +292,7 @@ components:
 func TestImageFinder_NodeImages(t *testing.T) {
 	s, err := converter.FromYAMLString(componentDataNodeConfig).ToBundle()
 	if err != nil {
-		t.Fatalf("error converting data: %v", err)
+		t.Fatal(err)
 	}
 
 	found := NewImageFinder(s.Components).AllContainerImages()
@@ -397,7 +397,7 @@ components:
 func TestImageFinder_AllFlattened(t *testing.T) {
 	s, err := converter.FromYAMLString(componentExampleAll).ToBundle()
 	if err != nil {
-		t.Fatalf("error converting data: %v", err)
+		t.Fatal(err)
 	}
 
 	found := NewImageFinder(s.Components).AllImages().Flattened()
@@ -417,7 +417,7 @@ func TestImageFinder_AllFlattened(t *testing.T) {
 func TestImageFinder_WalkTransform(t *testing.T) {
 	s, err := converter.FromYAMLString(componentExampleAll).ToBundle()
 	if err != nil {
-		t.Fatalf("error converting bundle: %v", err)
+		t.Fatal(err)
 	}
 
 	finder := NewImageFinder(s.Components)

--- a/pkg/options/rawyamltmpl/raw_text_applier_test.go
+++ b/pkg/options/rawyamltmpl/raw_text_applier_test.go
@@ -65,7 +65,7 @@ spec:
 func TestRawStringApplier_MultiItems(t *testing.T) {
 	comp, err := converter.FromYAMLString(dataComponent).ToComponent()
 	if err != nil {
-		t.Fatalf("Error converting component to yaml: %v", err)
+		t.Fatal(err)
 	}
 
 	usedParams := map[string]interface{}{

--- a/pkg/options/simpletemplate/simple_applier_test.go
+++ b/pkg/options/simpletemplate/simple_applier_test.go
@@ -41,7 +41,7 @@ spec:
 func TestSimpleApplier(t *testing.T) {
 	comp, err := converter.FromYAMLString(component).ToComponent()
 	if err != nil {
-		t.Fatalf("Error converting component to yaml: %v", err)
+		t.Fatal(err)
 	}
 
 	usedParams := map[string]interface{}{
@@ -124,7 +124,7 @@ spec:
 func TestSimpleApplier_MultiItems(t *testing.T) {
 	comp, err := converter.FromYAMLString(multiComponent).ToComponent()
 	if err != nil {
-		t.Fatalf("Error converting component to yaml: %v", err)
+		t.Fatal(err)
 	}
 
 	usedParams := map[string]interface{}{

--- a/pkg/validate/validate_component_test.go
+++ b/pkg/validate/validate_component_test.go
@@ -330,11 +330,11 @@ components:
 		t.Run(tc.desc, func(t *testing.T) {
 			set, err := converter.FromYAMLString(tc.set).ToComponentSet()
 			if err != nil {
-				t.Fatalf("error converting component set: %v", err)
+				t.Fatal(err)
 			}
 			comp, err := converter.FromYAMLString(tc.components).ToBundle()
 			if err != nil {
-				t.Fatalf("error converting component data: %v. was:\n%s", err, tc.components)
+				t.Fatal(err)
 			}
 			if err = checkErrCases(All(comp.Components, set).ToAggregate(), tc.errSubstring); err != nil {
 				t.Errorf(err.Error())
@@ -405,11 +405,11 @@ components:
 		t.Run(tc.desc, func(t *testing.T) {
 			set, err := converter.FromYAMLString(tc.set).ToComponentSet()
 			if err != nil {
-				t.Fatalf("error converting component set: %v", err)
+				t.Fatal(err)
 			}
 			comp, err := converter.FromYAMLString(tc.components).ToBundle()
 			if err != nil {
-				t.Fatalf("error converting component data: %v. was:\n%s", err, tc.components)
+				t.Fatal(err)
 			}
 			if errs := All(comp.Components, set); len(errs) != tc.numErrors {
 				t.Errorf("got %d errors. expected exactly %d. errors were: %v", len(errs), tc.numErrors, errs)


### PR DESCRIPTION
Fixes: #119

* Adds filename to error messages during encodeng.
* Removes demux/mux private methods that I missed
* Add slightly more helpful error messages in converting library
* Update inlining error messages during conversion.
* Clean up existing conversion error message usage.