### PR TITLE
Implement export of Bundle to ComponentSet

### DIFF
--- a/config/crds/bundle_v1alpha1_bundlebuilder.yaml
+++ b/config/crds/bundle_v1alpha1_bundlebuilder.yaml
@@ -39,6 +39,13 @@ spec:
                 type: string
             type: object
           type: array
+        componentNamePolicy:
+          description: ComponentNamePolicy defines how to generate the metadata.name
+            for a Component or ComponentBuilder that does not already have one.  -
+            SetAndComponent generates a name from the set name and version and    component
+            name and version.  - Component (default) generates a name from the component
+            name and version
+          type: string
         kind:
           description: 'Kind is a string value representing the REST resource this
             object represents. Servers may infer this from the endpoint the client

--- a/pkg/apis/bundle/v1alpha1/BUILD.bazel
+++ b/pkg/apis/bundle/v1alpha1/BUILD.bazel
@@ -29,5 +29,8 @@ go_test(
     name = "go_default_test",
     srcs = ["helpers_test.go"],
     embed = [":go_default_library"],
-    deps = ["//vendor/k8s.io/api/core/v1:go_default_library"],
+    deps = [
+        "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+    ],
 )

--- a/pkg/apis/bundle/v1alpha1/builder_types.go
+++ b/pkg/apis/bundle/v1alpha1/builder_types.go
@@ -34,6 +34,13 @@ type BundleBuilder struct {
 	// details. The version is optional for the ComponentBuilder
 	Version string `json:"version,omitempty"`
 
+	// ComponentNamePolicy defines how to generate the metadata.name
+	// for a Component or ComponentBuilder that does not already have one.
+	//  - SetAndComponent generates a name from the set name and version and
+	//    component name and version.
+	//  - Component (default) generates a name from the component name and version
+	ComponentNamePolicy string `json:"componentNamePolicy,omitempty"`
+
 	// ComponentFiles represent ComponentBuilder or Component types that are
 	// referenced via file urls.
 	ComponentFiles []File `json:"componentFiles,omitempty"`

--- a/pkg/apis/bundle/v1alpha1/helpers.go
+++ b/pkg/apis/bundle/v1alpha1/helpers.go
@@ -19,6 +19,7 @@ import (
 	"net/url"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // CreateName creates a name string to be used for ObjectMeta.Name. It
@@ -86,6 +87,10 @@ func (c *ComponentBuilder) ComponentReference() ComponentReference {
 // creation.
 func (b *Bundle) ComponentSet() *ComponentSet {
 	cset := &ComponentSet{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "bundle.gke.io/v1alpha1",
+			Kind:       "ComponentSet",
+		},
 		Spec: ComponentSetSpec{
 			SetName: b.SetName,
 			Version: b.Version,
@@ -94,6 +99,7 @@ func (b *Bundle) ComponentSet() *ComponentSet {
 	for _, comp := range b.Components {
 		cset.Spec.Components = append(cset.Spec.Components, comp.ComponentReference())
 	}
+	cset.MakeAndSetName()
 	return cset
 }
 

--- a/pkg/apis/bundle/v1alpha1/helpers_test.go
+++ b/pkg/apis/bundle/v1alpha1/helpers_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
-        metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestCreateName(t *testing.T) {
@@ -153,10 +153,10 @@ func TestMakeComponentSet(t *testing.T) {
 
 	got := b.ComponentSet()
 	exp := &ComponentSet{
-                TypeMeta: metav1.TypeMeta{
-                        APIVersion: "bundle.gke.io/v1alpha1",
-                        Kind:       "ComponentSet",
-                },
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "bundle.gke.io/v1alpha1",
+			Kind:       "ComponentSet",
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "zorp-0.1.0",
 		},

--- a/pkg/apis/bundle/v1alpha1/helpers_test.go
+++ b/pkg/apis/bundle/v1alpha1/helpers_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+        metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestCreateName(t *testing.T) {
@@ -152,6 +153,13 @@ func TestMakeComponentSet(t *testing.T) {
 
 	got := b.ComponentSet()
 	exp := &ComponentSet{
+                TypeMeta: metav1.TypeMeta{
+                        APIVersion: "bundle.gke.io/v1alpha1",
+                        Kind:       "ComponentSet",
+                },
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "zorp-0.1.0",
+		},
 		Spec: ComponentSetSpec{
 			SetName: "zorp",
 			Version: "0.1.0",

--- a/pkg/apis/bundle/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/bundle/v1alpha1/zz_generated.deepcopy.go
@@ -32,10 +32,11 @@ func (in *Bundle) DeepCopyInto(out *Bundle) {
 		in, out := &in.Components, &out.Components
 		*out = make([]*Component, len(*in))
 		for i := range *in {
-			if (*in)[i] != nil {
-				in, out := &(*in)[i], &(*out)[i]
-				*out = new(Component)
-				(*in).DeepCopyInto(*out)
+			if (*in)[i] == nil {
+				(*out)[i] = nil
+			} else {
+				(*out)[i] = new(Component)
+				(*in)[i].DeepCopyInto((*out)[i])
 			}
 		}
 	}
@@ -293,9 +294,11 @@ func (in *ComponentSpec) DeepCopyInto(out *ComponentSpec) {
 		in, out := &in.Objects, &out.Objects
 		*out = make([]*unstructured.Unstructured, len(*in))
 		for i := range *in {
-			if (*in)[i] != nil {
-				in, out := &(*in)[i], &(*out)[i]
-				*out = (*in).DeepCopy()
+			if (*in)[i] == nil {
+				(*out)[i] = nil
+			} else {
+				(*out)[i] = new(unstructured.Unstructured)
+				(*in)[i].DeepCopyInto((*out)[i])
 			}
 		}
 	}
@@ -356,7 +359,11 @@ func (in *PatchTemplate) DeepCopyInto(out *PatchTemplate) {
 	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
 	if in.OptionsSchema != nil {
 		in, out := &in.OptionsSchema, &out.OptionsSchema
-		*out = (*in).DeepCopy()
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = (*in).DeepCopy()
+		}
 	}
 	return
 }
@@ -386,11 +393,19 @@ func (in *PatchTemplateBuilder) DeepCopyInto(out *PatchTemplateBuilder) {
 	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
 	if in.BuildSchema != nil {
 		in, out := &in.BuildSchema, &out.BuildSchema
-		*out = (*in).DeepCopy()
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = (*in).DeepCopy()
+		}
 	}
 	if in.TargetSchema != nil {
 		in, out := &in.TargetSchema, &out.TargetSchema
-		*out = (*in).DeepCopy()
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = (*in).DeepCopy()
+		}
 	}
 	return
 }

--- a/pkg/build/inline.go
+++ b/pkg/build/inline.go
@@ -84,7 +84,7 @@ func (n *Inliner) BundleFiles(ctx context.Context, data *bundle.BundleBuilder) (
 			if err != nil {
 				return nil, fmt.Errorf("error converting file %q to a component builder: %v", f.URL, err)
 			}
-			if c.GetName() == "" {
+			if c.GetName() == "" && data.ComponentNamePolicy == "SetAndComponent" {
 				c.ObjectMeta.Name = strings.Join([]string{data.SetName, data.Version, c.ComponentName, c.Version}, "-")
 			}
 			compbs = append(compbs, c)

--- a/pkg/build/inline.go
+++ b/pkg/build/inline.go
@@ -84,6 +84,9 @@ func (n *Inliner) BundleFiles(ctx context.Context, data *bundle.BundleBuilder) (
 			if err != nil {
 				return nil, fmt.Errorf("error converting file %q to a component builder: %v", f.URL, err)
 			}
+			if c.GetName() == "" {
+				c.ObjectMeta.Name = strings.Join([]string{data.SetName, data.Version, c.ComponentName, c.Version}, "-")
+			}
 			compbs = append(compbs, c)
 		default:
 			return nil, fmt.Errorf("unsupported kind for component: %q; only supported kinds are Component and ComponentBuilder", kind)

--- a/pkg/build/inline_test.go
+++ b/pkg/build/inline_test.go
@@ -152,6 +152,35 @@ componentFiles:
 		},
 
 		{
+			desc: "success: inline basic bundle + file prefix + SetAndComponent policy",
+			data: `
+kind: BundleBuilder
+setName: foo-bundle
+version: 1.2.3
+componentNamePolicy: SetAndComponent
+componentFiles:
+- url: file:///path/to/apiserver-component.yaml`,
+			files:  defaultFiles,
+			expBun: bundleRef{setName: "foo-bundle", version: "1.2.3"},
+			expComps: []compRef{
+				{
+					name: "foo-bundle-1.2.3-kube-apiserver-1.2.3",
+					ref: bundle.ComponentReference{
+						ComponentName: "kube-apiserver",
+						Version:       "1.2.3",
+					},
+					obj: []objCheck{
+						{
+							name:     "biffbam",
+							annotKey: string(bundle.InlineTypeIdentifier),
+							annotVal: string(bundle.KubeObjectInline),
+						},
+					},
+				},
+			},
+		},
+
+		{
 			desc: "success: inline bundle with raw text",
 			data: `
 kind: BundleBuilder

--- a/pkg/commands/export/BUILD.bazel
+++ b/pkg/commands/export/BUILD.bazel
@@ -14,6 +14,5 @@ go_library(
         "//pkg/files:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",
     ],
 )

--- a/pkg/commands/export/export.go
+++ b/pkg/commands/export/export.go
@@ -23,7 +23,6 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/files"
 	log "github.com/golang/glog"
 	"github.com/spf13/cobra"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 // options represents options flags for the export command.
@@ -50,15 +49,11 @@ func run(ctx context.Context, o *options, brw cmdlib.BundleReaderWriter, stdio c
 		return fmt.Errorf("error reading bundle contents: %v", err)
 	}
 
-	comps := bw.AllComponents()
-	if len(comps) == 0 {
-		return nil
+	objs, err := bw.ExportAsObjects()
+	if err != nil {
+		return err
 	}
 
-	var objs []*unstructured.Unstructured
-	for _, c := range comps {
-		objs = append(objs, c.Spec.Objects...)
-	}
 	exporter := converter.ObjectExporter{Objects: objs}
 	s, err := exporter.ExportAsYAML()
 	if err != nil {

--- a/pkg/wrapper/BUILD.bazel
+++ b/pkg/wrapper/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//pkg/apis/bundle/v1alpha1:go_default_library",
         "//pkg/converter:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",
     ],
 )
 

--- a/pkg/wrapper/bundlewrapper.go
+++ b/pkg/wrapper/bundlewrapper.go
@@ -21,6 +21,7 @@ import (
 
 	bundle "github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/apis/bundle/v1alpha1"
 	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/converter"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 // BundleWrapper represents one of several possible bundle types -- a union type.
@@ -147,4 +148,37 @@ func (bw *BundleWrapper) AllComponents() []*bundle.Component {
 		return []*bundle.Component{bw.component}
 	}
 	return nil
+}
+
+func (bw *BundleWrapper) ExportAsObjects() ([]*unstructured.Unstructured, error) {
+	switch bw.Kind() {
+	case "Component":
+		return bw.Component().Spec.Objects, nil
+	case "Bundle":
+		bun := bw.Bundle()
+		y, err := converter.FromObject(bun.ComponentSet()).ToYAML()
+		if err != nil {
+			return nil, err
+		}
+		o, err := converter.FromYAML(y).ToUnstructured()
+		if err != nil {
+			return nil, err
+		}
+		var objs []*unstructured.Unstructured
+		objs = append(objs, o)
+		for _, c := range bun.Components {
+			y, err := converter.FromObject(c).ToYAML()
+			if err != nil {
+				return nil, err
+			}
+			o, err := converter.FromYAML(y).ToUnstructured()
+			if err != nil {
+				return nil, err
+			}
+			objs = append(objs, o)
+		}
+		return objs, nil
+	default:
+		return nil, fmt.Errorf("bundle kind %q not supported for exporting", bw.Kind())
+	}
 }

--- a/pkg/wrapper/bundlewrapper.go
+++ b/pkg/wrapper/bundlewrapper.go
@@ -150,6 +150,8 @@ func (bw *BundleWrapper) AllComponents() []*bundle.Component {
 	return nil
 }
 
+// ExportAsObjects will export a Bundle as a ComponentSet and Components,
+// or a Component as unstructured Objects.
 func (bw *BundleWrapper) ExportAsObjects() ([]*unstructured.Unstructured, error) {
 	switch bw.Kind() {
 	case "Component":


### PR DESCRIPTION
* Change default component name to include component set name and
version when in a component set (prevents component sets from
overwriting other component sets components)

* Move Export code into wrapper so that it can be used when using this
code as a library rather than using the CLI.

* Exporting a Bundle now results in a ComponentSet and Components, rather than all objects of all components in the bundle.