### PR TITLE
Change string-map flag to more standard format.

### DIFF
--- a/examples/component/README.md
+++ b/examples/component/README.md
@@ -21,7 +21,7 @@ Alternatively, a subset of patches can be applied with:
 go run ../../cmd/bundlectl/main.go patch \
   --input-file=etcd-component.yaml \
   --options-file=options.yaml \
-  --patch-annotations=build-label-experiment,test
+  --patch-annotations=build-label-experiment=test
 ```
 
 ## Patch Templates

--- a/pkg/commands/build/add_commands.go
+++ b/pkg/commands/build/add_commands.go
@@ -37,8 +37,5 @@ func AddCommandsTo(ctx context.Context, root *cobra.Command) {
 	cmd.Flags().StringVarP(&opts.optionsFile, "options-file", "", "",
 		"File containing options to apply to patch templates")
 
-	cmd.Flags().StringVarP(&opts.annotations, "annotations", "", "",
-		"Select a subset of patch templates to build to apply based on a list of annotations of the form \"key1,val1;key2,val2;\"")
-
 	root.AddCommand(cmd)
 }

--- a/pkg/commands/build/build.go
+++ b/pkg/commands/build/build.go
@@ -28,10 +28,6 @@ import (
 
 // options represents options flags for the build command.
 type options struct {
-	// annotations selects a subset of patch templates on which to apply options
-	// Has the form "foo,bar;biff,baz".
-	annotations string
-
 	// optionsFile contains yaml or json structured data containing options to
 	// apply to PatchTemplates
 	// TODO(jbelamaric): Make this a list of files

--- a/pkg/commands/cmdlib/bundleio.go
+++ b/pkg/commands/cmdlib/bundleio.go
@@ -205,16 +205,17 @@ func formatFromFile(path string) string {
 	return ""
 }
 
-// ParseAnnotations parses CLI flag format for annotations
-func ParseAnnotations(p string) map[string]string {
+// ParseStringMap parses a CLI flag value into a map of string to string. It
+// expects the raw flag value to have the form "key1=value1,key2=value2,etc".
+func ParseStringMap(p string) map[string]string {
 	if p == "" {
 		return nil
 	}
 
 	m := make(map[string]string)
-	splat := strings.Split(p, ";")
+	splat := strings.Split(p, ",")
 	for _, v := range splat {
-		kv := strings.Split(v, ",")
+		kv := strings.Split(v, "=")
 		if len(kv) == 2 {
 			m[kv[0]] = kv[1]
 		}

--- a/pkg/commands/filter/add_commands.go
+++ b/pkg/commands/filter/add_commands.go
@@ -40,9 +40,9 @@ func AddCommandsTo(ctx context.Context, root *cobra.Command) {
 	cmd.Flags().StringVarP(&opts.namespaces, "namespaces", "", "",
 		"Comma separated namespaces to filter on")
 	cmd.Flags().StringVarP(&opts.annotations, "annotations", "", "",
-		"Comma + semicolon separated annotations to filter on. Ex: 'foo,bar;biff,bam'")
+		"Comma + semicolon separated annotations to filter on. Ex: 'foo=bar,biff=bam'")
 	cmd.Flags().StringVarP(&opts.labels, "labels", "", "",
-		"Comma + semicolon separated labelsto filter on. Ex: 'foo,bar;biff,bam'")
+		"Comma + semicolon separated labelsto filter on. Ex: 'foo=bar,biff=bam'")
 	cmd.Flags().BoolVarP(&opts.keepOnly, "keep-only", "", false,
 		"Whether to keep options instead of filtering them")
 

--- a/pkg/commands/filter/filter.go
+++ b/pkg/commands/filter/filter.go
@@ -42,11 +42,11 @@ type options struct {
 	namespaces string
 
 	// Comma + semicolon separated annotations to filter
-	// Example: foo,bar;biff,bam
+	// Example: foo=bar,biff=bam
 	annotations string
 
 	// Comma + semicolon separated annotations to filter
-	// Example: foo,bar;biff,bam
+	// Example: foo=bar,biff=bam
 	labels string
 
 	// Whether to keep matches rather then remove them.
@@ -83,26 +83,10 @@ func run(ctx context.Context, o *options, brw cmdlib.BundleReaderWriter, gopt *c
 		fopts.Namespaces = strings.Split(o.namespaces, ",")
 	}
 	if o.annotations != "" {
-		m := make(map[string]string)
-		splat := strings.Split(o.annotations, ";")
-		for _, v := range splat {
-			kv := strings.Split(v, ",")
-			if len(kv) == 2 {
-				m[kv[0]] = kv[1]
-			}
-		}
-		fopts.Annotations = m
+		fopts.Annotations = cmdlib.ParseStringMap(o.annotations)
 	}
 	if o.labels != "" {
-		m := make(map[string]string)
-		splat := strings.Split(o.labels, ";")
-		for _, v := range splat {
-			kv := strings.Split(v, ",")
-			if len(kv) == 2 {
-				m[kv[0]] = kv[1]
-			}
-		}
-		fopts.Labels = m
+		fopts.Labels = cmdlib.ParseStringMap(o.labels)
 	}
 	fopts.KeepOnly = o.keepOnly
 

--- a/pkg/commands/patch/add_commands.go
+++ b/pkg/commands/patch/add_commands.go
@@ -39,7 +39,7 @@ func AddCommandsTo(ctx context.Context, root *cobra.Command) {
 		"File containing options to apply to patch templates. May be repeated, later values override earlier ones.")
 
 	cmd.Flags().StringVar(&opts.patchAnnotations, "patch-annotations", "",
-		"Select a subset of patches to apply based on a list of annotations of the form \"key1,val1;key2,val2;\"")
+		"Select a subset of patches to apply based on a list of annotations of the form \"key1=val1,key2=val2\"")
 
 	cmd.Flags().BoolVar(&opts.keepTemplates, "keep-templates", false,
 		"Do not remove templates that have been applied from the component.")

--- a/pkg/commands/patch/patch.go
+++ b/pkg/commands/patch/patch.go
@@ -32,7 +32,7 @@ import (
 // options represents options flags for the filter command.
 type options struct {
 	// patchAnnotations selects a subset of patch templates to apply via annotations.
-	// Has the form "foo,bar;biff,baz".
+	// Has the form "foo=bar,biff=baz".
 	patchAnnotations string
 
 	// optionsFiles contains yaml or json structured data containing options to
@@ -69,7 +69,7 @@ func run(ctx context.Context, o *options, brw cmdlib.BundleReaderWriter, rw file
 		return err
 	}
 
-	fopts := &filter.Options{Annotations: cmdlib.ParseAnnotations(o.patchAnnotations)}
+	fopts := &filter.Options{Annotations: cmdlib.ParseStringMap(o.patchAnnotations)}
 	applier := patchtmpl.NewApplier(patchtmpl.DefaultPatcherScheme(), fopts, o.keepTemplates)
 
 	switch bw.Kind() {


### PR DESCRIPTION
This changes the string map flag to a more standard format, from
"foo,bar;biff,bam" to "foo=bar,biff=bam".

Fixes: #163