### PR TITLE
Move file/std io to top-level to allow for dependency-injection.

### DIFF
--- a/pkg/commands/BUILD.bazel
+++ b/pkg/commands/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "//pkg/commands/find:go_default_library",
         "//pkg/commands/patch:go_default_library",
         "//pkg/commands/validate:go_default_library",
+        "//pkg/files:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",
     ],
 )

--- a/pkg/commands/build/add_commands.go
+++ b/pkg/commands/build/add_commands.go
@@ -18,16 +18,17 @@ import (
 	"context"
 
 	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/commands/cmdlib"
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/files"
 	"github.com/spf13/cobra"
 )
 
 // AddCommandsTo adds commands to a root cobra command.
-func AddCommandsTo(ctx context.Context, root *cobra.Command) {
+func AddCommandsTo(ctx context.Context, fio files.FileReaderWriter, sio cmdlib.StdioReaderWriter, root *cobra.Command) {
 	cmd := &cobra.Command{
 		Use:   "build",
 		Short: "Build the bundle files",
 		Long:  `Build all the files in the given bundle yaml`,
-		Run:   cmdlib.ContextAction(ctx, action),
+		Run:   cmdlib.ContextAction(ctx, fio, sio, action),
 	}
 
 	// Optional flags

--- a/pkg/commands/build/build.go
+++ b/pkg/commands/build/build.go
@@ -41,14 +41,11 @@ type options struct {
 // opts is a global options instance for reference via the add commands.
 var opts = &options{}
 
-func action(ctx context.Context, cmd *cobra.Command, _ []string) {
+func action(ctx context.Context, fio files.FileReaderWriter, sio cmdlib.StdioReaderWriter, cmd *cobra.Command, _ []string) {
 	gopt := cmdlib.GlobalOptionsValues.Copy()
 	gopt.Inline = true
-	rw := &files.LocalFileSystemReaderWriter{}
-	brw := cmdlib.NewBundleReaderWriter(
-		rw,
-		&cmdlib.RealStdioReaderWriter{})
-	if err := run(ctx, opts, brw, rw, gopt); err != nil {
+	brw := cmdlib.NewBundleReaderWriter(fio, sio)
+	if err := run(ctx, opts, brw, fio, gopt); err != nil {
 		log.Exit(err)
 	}
 }

--- a/pkg/commands/cmdlib/cmdlib.go
+++ b/pkg/commands/cmdlib/cmdlib.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"os"
 
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/files"
 	log "github.com/golang/glog"
 	"github.com/spf13/cobra"
 )
@@ -30,14 +31,14 @@ func ExitWithHelp(cmd *cobra.Command, err string) {
 }
 
 // ContextActionFunc is a common type for providing a context to a Cobra function.
-type ContextActionFunc func(ctx context.Context, cmd *cobra.Command, args []string)
+type ContextActionFunc func(ctx context.Context, fio files.FileReaderWriter, sio StdioReaderWriter, cmd *cobra.Command, args []string)
 
 // CobraActionFunc provides a common type for all Cobra commands.
 type CobraActionFunc func(cmd *cobra.Command, args []string)
 
 // ContextAction returns a CobraActionFunc for a provided ContextActionFunc.
-func ContextAction(ctx context.Context, f ContextActionFunc) CobraActionFunc {
+func ContextAction(ctx context.Context, fio files.FileReaderWriter, sio StdioReaderWriter, f ContextActionFunc) CobraActionFunc {
 	return func(cmd *cobra.Command, args []string) {
-		f(ctx, cmd, args)
+		f(ctx, fio, sio, cmd, args)
 	}
 }

--- a/pkg/commands/export/add_commands.go
+++ b/pkg/commands/export/add_commands.go
@@ -18,16 +18,17 @@ import (
 	"context"
 
 	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/commands/cmdlib"
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/files"
 	"github.com/spf13/cobra"
 )
 
 // AddCommandsTo adds commands to a root cobra command.
-func AddCommandsTo(ctx context.Context, root *cobra.Command) {
+func AddCommandsTo(ctx context.Context, fio files.FileReaderWriter, sio cmdlib.StdioReaderWriter, root *cobra.Command) {
 	cmd := &cobra.Command{
 		Use:   "export",
 		Short: "Exports all of the objects",
 		Long:  `Exports all objects to STDOUT as YAML delimited by ---`,
-		Run:   cmdlib.ContextAction(ctx, action),
+		Run:   cmdlib.ContextAction(ctx, fio, sio, action),
 	}
 
 	root.AddCommand(cmd)

--- a/pkg/commands/export/export.go
+++ b/pkg/commands/export/export.go
@@ -31,19 +31,15 @@ type options struct{}
 // opts is a global options instance for reference via the add commands.
 var opts = &options{}
 
-func action(ctx context.Context, cmd *cobra.Command, _ []string) {
+func action(ctx context.Context, fio files.FileReaderWriter, sio cmdlib.StdioReaderWriter, cmd *cobra.Command, _ []string) {
 	gopt := cmdlib.GlobalOptionsValues.Copy()
-	stdio := cmdlib.RealStdioReaderWriter{}
-	brw := cmdlib.NewBundleReaderWriter(
-		&files.LocalFileSystemReaderWriter{},
-		&stdio,
-	)
-	if err := run(ctx, opts, brw, stdio, gopt); err != nil {
+	brw := cmdlib.NewBundleReaderWriter(fio, sio)
+	if err := run(ctx, opts, brw, sio, gopt); err != nil {
 		log.Exit(err)
 	}
 }
 
-func run(ctx context.Context, o *options, brw cmdlib.BundleReaderWriter, stdio cmdlib.RealStdioReaderWriter, gopt *cmdlib.GlobalOptions) error {
+func run(ctx context.Context, o *options, brw cmdlib.BundleReaderWriter, stdio cmdlib.StdioReaderWriter, gopt *cmdlib.GlobalOptions) error {
 	bw, err := brw.ReadBundleData(ctx, gopt)
 	if err != nil {
 		return fmt.Errorf("error reading bundle contents: %v", err)

--- a/pkg/commands/filter/add_commands.go
+++ b/pkg/commands/filter/add_commands.go
@@ -18,16 +18,17 @@ import (
 	"context"
 
 	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/commands/cmdlib"
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/files"
 	"github.com/spf13/cobra"
 )
 
 // AddCommandsTo adds commands to a root cobra command.
-func AddCommandsTo(ctx context.Context, root *cobra.Command) {
+func AddCommandsTo(ctx context.Context, fio files.FileReaderWriter, sio cmdlib.StdioReaderWriter, root *cobra.Command) {
 	cmd := &cobra.Command{
 		Use:   "filter",
 		Short: "Filter the components or objects in a bundle file",
 		Long:  `Filter the components or objects in a bundle file, returning a new bundle file`,
-		Run:   cmdlib.ContextAction(ctx, action),
+		Run:   cmdlib.ContextAction(ctx, fio, sio, action),
 	}
 
 	// Optional flags

--- a/pkg/commands/filter/filter.go
+++ b/pkg/commands/filter/filter.go
@@ -56,11 +56,9 @@ type options struct {
 // opts is a global options instance for reference via the add commands.
 var opts = &options{}
 
-func action(ctx context.Context, cmd *cobra.Command, _ []string) {
+func action(ctx context.Context, fio files.FileReaderWriter, sio cmdlib.StdioReaderWriter, cmd *cobra.Command, _ []string) {
 	gopt := cmdlib.GlobalOptionsValues.Copy()
-	brw := cmdlib.NewBundleReaderWriter(
-		&files.LocalFileSystemReaderWriter{},
-		&cmdlib.RealStdioReaderWriter{})
+	brw := cmdlib.NewBundleReaderWriter(fio, sio)
 	if err := run(ctx, opts, brw, gopt); err != nil {
 		log.Exit(err)
 	}

--- a/pkg/commands/find/add_commands.go
+++ b/pkg/commands/find/add_commands.go
@@ -18,11 +18,12 @@ import (
 	"context"
 
 	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/commands/cmdlib"
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/files"
 	"github.com/spf13/cobra"
 )
 
 // AddCommandsTo adds commands to a root cobra command.
-func AddCommandsTo(ctx context.Context, root *cobra.Command) {
+func AddCommandsTo(ctx context.Context, fio files.FileReaderWriter, sio cmdlib.StdioReaderWriter, root *cobra.Command) {
 	// cmd is the parent image command, and is unrunnable by itself.
 	cmd := &cobra.Command{
 		Use:   "find",
@@ -34,7 +35,7 @@ func AddCommandsTo(ctx context.Context, root *cobra.Command) {
 		Use:   "images",
 		Short: "Find images in the bundle",
 		Long:  "Apply all the patches found in a bundle to customize it with the given options custom resources",
-		Run:   cmdlib.ContextAction(ctx, findAction),
+		Run:   cmdlib.ContextAction(ctx, fio, sio, findAction),
 	}
 
 	cmd.AddCommand(imagesCmd)

--- a/pkg/commands/find/images.go
+++ b/pkg/commands/find/images.go
@@ -31,11 +31,9 @@ type options struct {
 
 var opts = &options{}
 
-func findAction(ctx context.Context, cmd *cobra.Command, _ []string) {
+func findAction(ctx context.Context, fio files.FileReaderWriter, sio cmdlib.StdioReaderWriter, cmd *cobra.Command, _ []string) {
 	gopt := cmdlib.GlobalOptionsValues.Copy()
-	brw := cmdlib.NewBundleReaderWriter(
-		&files.LocalFileSystemReaderWriter{},
-		&cmdlib.RealStdioReaderWriter{})
+	brw := cmdlib.NewBundleReaderWriter(fio, sio)
 	if err := runFindImages(ctx, opts, brw, gopt); err != nil {
 		log.Exitf("error in runFindImages: %v", err)
 	}

--- a/pkg/commands/patch/add_commands.go
+++ b/pkg/commands/patch/add_commands.go
@@ -18,17 +18,18 @@ import (
 	"context"
 
 	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/commands/cmdlib"
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/files"
 	"github.com/spf13/cobra"
 )
 
 // AddCommandsTo adds commands to a root cobra command.
-func AddCommandsTo(ctx context.Context, root *cobra.Command) {
+func AddCommandsTo(ctx context.Context, fio files.FileReaderWriter, sio cmdlib.StdioReaderWriter, root *cobra.Command) {
 	cmd := &cobra.Command{
 		Use:   "patch",
 		Short: "Apply patch templates to component objects",
 		Long: "Apply patch templates to component objects. " +
 			"Options are usually applied to the templates before application.",
-		Run: cmdlib.ContextAction(ctx, action),
+		Run: cmdlib.ContextAction(ctx, fio, sio, action),
 	}
 
 	// Optional flags

--- a/pkg/commands/patch/patch.go
+++ b/pkg/commands/patch/patch.go
@@ -47,13 +47,10 @@ type options struct {
 // opts is a global options instance for reference via the add commands.
 var opts = &options{}
 
-func action(ctx context.Context, cmd *cobra.Command, _ []string) {
+func action(ctx context.Context, fio files.FileReaderWriter, sio cmdlib.StdioReaderWriter, cmd *cobra.Command, _ []string) {
 	gopt := cmdlib.GlobalOptionsValues.Copy()
-	rw := &files.LocalFileSystemReaderWriter{}
-	brw := cmdlib.NewBundleReaderWriter(
-		rw,
-		&cmdlib.RealStdioReaderWriter{})
-	if err := run(ctx, opts, brw, rw, gopt); err != nil {
+	brw := cmdlib.NewBundleReaderWriter(fio, sio)
+	if err := run(ctx, opts, brw, fio, gopt); err != nil {
 		log.Exit(err)
 	}
 }

--- a/pkg/commands/validate/add_commands.go
+++ b/pkg/commands/validate/add_commands.go
@@ -18,16 +18,17 @@ import (
 	"context"
 
 	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/commands/cmdlib"
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/files"
 	"github.com/spf13/cobra"
 )
 
 // AddCommandsTo adds commands to a root cobra command.
-func AddCommandsTo(ctx context.Context, root *cobra.Command) {
+func AddCommandsTo(ctx context.Context, fio files.FileReaderWriter, sio cmdlib.StdioReaderWriter, root *cobra.Command) {
 	cmd := &cobra.Command{
 		Use:   "validate",
 		Short: "Validate a bundle file",
 		Long:  `Validate a bundle file to ensure the bundle file follows the bundle schema and doesn't contain errors.`,
-		Run:   cmdlib.ContextAction(ctx, action),
+		Run:   cmdlib.ContextAction(ctx, fio, sio, action),
 	}
 
 	root.AddCommand(cmd)

--- a/pkg/commands/validate/validate.go
+++ b/pkg/commands/validate/validate.go
@@ -37,11 +37,9 @@ type options struct {
 var opts = &options{}
 
 // Action is the cobra command action for bundle validation.
-func action(ctx context.Context, cmd *cobra.Command, _ []string) {
+func action(ctx context.Context, fio files.FileReaderWriter, sio cmdlib.StdioReaderWriter, cmd *cobra.Command, _ []string) {
 	gopt := cmdlib.GlobalOptionsValues.Copy()
-	brw := cmdlib.NewBundleReaderWriter(
-		&files.LocalFileSystemReaderWriter{},
-		&cmdlib.RealStdioReaderWriter{})
+	brw := cmdlib.NewBundleReaderWriter(fio, sio)
 	if err := runValidate(ctx, opts, brw, gopt); err != nil {
 		log.Exit(err)
 	}


### PR DESCRIPTION
This should allow us to run deeper tests of commands, by allowing tests
in each of the command directories to run:

```
AddCommandsInternal(...deps...).Execute().
```

Partial work on #126