### PR TITLE
Chdir to the appropriate directory when run with bazel.

### DIFF
--- a/pkg/build/BUILD.bazel
+++ b/pkg/build/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = [
+        "bazel_init_test.go",
         "config_map_maker_test.go",
         "inline_integration_test.go",
         "inline_test.go",

--- a/pkg/build/bazel_init_test.go
+++ b/pkg/build/bazel_init_test.go
@@ -1,0 +1,23 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build
+
+import (
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/testutil"
+)
+
+func init() {
+	testutil.ChangeToBazelDir("pkg/build")
+}

--- a/pkg/build/inline_integration_test.go
+++ b/pkg/build/inline_integration_test.go
@@ -16,16 +16,16 @@ package build
 
 import (
 	"context"
+	"io/ioutil"
 	"testing"
 
 	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/converter"
-	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/testutil"
 	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/validate"
 )
 
 func TestRealisticDataParseAndInline_Bundle(t *testing.T) {
 	ctx := context.Background()
-	b, err := testutil.ReadData("../../", "examples/cluster/bundle-builder-example.yaml")
+	b, err := ioutil.ReadFile("../../examples/cluster/bundle-builder-example.yaml")
 	if err != nil {
 		t.Fatalf("Error reading file %v", err)
 	}
@@ -39,8 +39,7 @@ func TestRealisticDataParseAndInline_Bundle(t *testing.T) {
 		t.Fatalf("found zero files, but expected some")
 	}
 
-	pathPrefix := testutil.TestPathPrefix("../../", "examples/cluster/bundle-builder-example.yaml")
-	inliner := NewLocalInliner(pathPrefix)
+	inliner := NewLocalInliner("../../examples/cluster/")
 
 	moreInlined, err := inliner.BundleFiles(ctx, dataFiles)
 	if err != nil {
@@ -62,7 +61,7 @@ func TestRealisticDataParseAndInline_Bundle(t *testing.T) {
 
 func TestRealisticDataParseAndInline_Component(t *testing.T) {
 	ctx := context.Background()
-	b, err := testutil.ReadData("../../", "examples/component/etcd-component-builder.yaml")
+	b, err := ioutil.ReadFile("../../examples/component/etcd-component-builder.yaml")
 	if err != nil {
 		t.Fatalf("Error reading file %v", err)
 	}
@@ -76,8 +75,7 @@ func TestRealisticDataParseAndInline_Component(t *testing.T) {
 		t.Fatalf("found zero files, but expected some")
 	}
 
-	pathPrefix := testutil.TestPathPrefix("../../", "examples/component/etcd-component-builder.yaml")
-	inliner := NewLocalInliner(pathPrefix)
+	inliner := NewLocalInliner("../../examples/component/")
 
 	component, err := inliner.ComponentFiles(ctx, cb)
 	if err != nil {

--- a/pkg/converter/bazel_init_test.go
+++ b/pkg/converter/bazel_init_test.go
@@ -1,0 +1,23 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package converter
+
+import (
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/testutil"
+)
+
+func init() {
+	testutil.ChangeToBazelDir("pkg/converter")
+}

--- a/pkg/converter/converter_integration_test.go
+++ b/pkg/converter/converter_integration_test.go
@@ -15,13 +15,12 @@
 package converter
 
 import (
+	"io/ioutil"
 	"testing"
-
-	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/testutil"
 )
 
 func TestRealisticDataParse_BundleBuilder(t *testing.T) {
-	b, err := testutil.ReadData("../../", "examples/cluster/bundle-builder-example.yaml")
+	b, err := ioutil.ReadFile("../../examples/cluster/bundle-builder-example.yaml")
 	if err != nil {
 		t.Fatalf("Error reading file %v", err)
 	}
@@ -37,7 +36,7 @@ func TestRealisticDataParse_BundleBuilder(t *testing.T) {
 }
 
 func TestRealisticDataParse_ComponentSet(t *testing.T) {
-	b, err := testutil.ReadData("../../", "examples/cluster/component-set.yaml")
+	b, err := ioutil.ReadFile("../../examples/cluster/component-set.yaml")
 	if err != nil {
 		t.Fatalf("Error reading file %v", err)
 	}
@@ -53,7 +52,7 @@ func TestRealisticDataParse_ComponentSet(t *testing.T) {
 }
 
 func TestRealisticDataParse_ComponentBuilder(t *testing.T) {
-	b, err := testutil.ReadData("../../", "examples/component/etcd-component-builder.yaml")
+	b, err := ioutil.ReadFile("../../examples/component/etcd-component-builder.yaml")
 	if err != nil {
 		t.Fatalf("Error reading file %v", err)
 	}
@@ -69,7 +68,7 @@ func TestRealisticDataParse_ComponentBuilder(t *testing.T) {
 }
 
 func TestRealisticDataParse_Component(t *testing.T) {
-	b, err := testutil.ReadData("../../", "examples/component/etcd-component.yaml")
+	b, err := ioutil.ReadFile("../../examples/component/etcd-component.yaml")
 	if err != nil {
 		t.Fatalf("Error reading file %v", err)
 	}

--- a/pkg/testutil/testutil.go
+++ b/pkg/testutil/testutil.go
@@ -17,22 +17,21 @@
 package testutil
 
 import (
-	"io/ioutil"
+	"fmt"
 	"os"
 	"path/filepath"
 )
 
-// TestPathPrefix returns the empty string or the bazel test path prefix.
-func TestPathPrefix(pathToRoot, file string) string {
-	path := os.Getenv("TEST_SRCDIR") // For dealing with bazel.
-	workspace := os.Getenv("TEST_WORKSPACE")
-	if path != "" {
-		return filepath.Join(path, workspace, file)
+// ChangeToBazelDir changes the CWD to a bazel directory if necessary.
+// pathToDir specifies the path from the root bazel-directory to the relevant
+// directory.  If changing the directory fails, the method panics.
+func ChangeToBazelDir(curDir string) {
+	bazelTestPath := os.Getenv("TEST_SRCDIR")
+	if bazelTestPath != "" {
+		workspace := os.Getenv("TEST_WORKSPACE")
+		dir := filepath.Join(bazelTestPath, workspace, curDir)
+		if err := os.Chdir(dir); err != nil {
+			panic(fmt.Sprintf("os.Chdir(%q): %v", dir, err))
+		}
 	}
-	return filepath.Join(pathToRoot, file)
-}
-
-// ReadData reads the test-data from disk.
-func ReadData(pathToRoot, file string) ([]byte, error) {
-	return ioutil.ReadFile(TestPathPrefix(pathToRoot, file))
 }


### PR DESCRIPTION
This changes the cwd to the test-directory when run with Bazel. This makes testing much simpler *and* compatible with bazel \o/.