### PR TITLE
Add componentsuite, which adds functionality for testing components.

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,3 +269,11 @@ hacke/update-codegen.sh
 ```
 
 If new files are added, will to re-run Gazelle (see above).
+
+### Prow
+
+If the prow-jobs need to be updated, see:
+
+* Cluster Bundle Prow Jobs
+  * [historical, pinned](https://github.com/kubernetes/test-infra/blob/1f003d3e1d7aecad6e16fd08e9d0253df9033f20/config/jobs/GoogleCloudPlatform/k8s-cluster-bundle/k8s-cluster-bundle.yaml)
+  * [master](https://github.com/kubernetes/test-infra/blob/master/config/jobs/GoogleCloudPlatform/k8s-cluster-bundle/k8s-cluster-bundle.yaml)

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -1,8 +1,9 @@
 filegroup(
-    name = "component_testdata",
-    srcs = glob([
-        "**/*.yaml",
-        "**/*.txt",
-    ]),
+    name = "testdata",
+    srcs = [
+      "//examples/cluster:testdata",
+      "//examples/component:testdata",
+      "//examples/patchbuilder:testdata",
+    ],
     visibility = ["//visibility:public"],
 )

--- a/examples/cluster/BUILD.bazel
+++ b/examples/cluster/BUILD.bazel
@@ -1,0 +1,8 @@
+filegroup(
+    name = "testdata",
+    srcs = glob([
+        "**/*.yaml",
+        "**/*.txt",
+    ]),
+    visibility = ["//visibility:public"],
+)

--- a/examples/component/BUILD.bazel
+++ b/examples/component/BUILD.bazel
@@ -1,0 +1,8 @@
+filegroup(
+    name = "testdata",
+    srcs = glob([
+        "**/*.yaml",
+        "**/*.txt",
+    ]),
+    visibility = ["//visibility:public"],
+)

--- a/examples/patchbuilder/BUILD.bazel
+++ b/examples/patchbuilder/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_test")
+
+filegroup(
+    name = "testdata",
+    srcs = glob([
+        "**/*.yaml",
+        "**/*.txt",
+    ]),
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "bazel_init_test.go",
+        "component_test.go",
+    ],
+    data = [":testdata"],
+    deps = [
+        "//pkg/testutil:go_default_library",
+        "//pkg/testutil/componentsuite:go_default_library",
+    ],
+)

--- a/examples/patchbuilder/bazel_init_test.go
+++ b/examples/patchbuilder/bazel_init_test.go
@@ -1,0 +1,23 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package patchbuilder
+
+import (
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/testutil"
+)
+
+func init() {
+	testutil.ChangeToBazelDir("examples/patchbuilder")
+}

--- a/examples/patchbuilder/component-test.yaml
+++ b/examples/patchbuilder/component-test.yaml
@@ -9,11 +9,17 @@ testCases:
     options:
       Namespace: default
   expect:
-    findSubstrs:
-      Deployment-helloweb:
+    objects:
+    - kind: Deployment
+      name: helloweb
+      findSubstrs:
       - 'namespace: default'
       - 'image: gcr.io/google-samples/hello-app:2.0'
-      Service-helloweb:
+      notFindSubstrs:
+      - 'image: gcr.io/google-samples/hello-app:1.0'
+    - kind: Service
+      name: helloweb
+      findSubstrs:
       - 'targetPort: 8080'
 
 - description: 'Success: change port'
@@ -25,11 +31,15 @@ testCases:
       Namespace: default
       Port: 8888
   expect:
-    findSubstrs:
-      Deployment-helloweb:
+    objects:
+    - kind: Deployment
+      name: helloweb
+      findSubstrs:
       - 'namespace: default'
       - 'image: gcr.io/google-samples/hello-app:2.0'
-      Service-helloweb:
+    - kind: Service
+      name: helloweb
+      findSubstrs:
       - 'targetPort: 8888'
 
 - description: 'Error: no image Tag'

--- a/examples/patchbuilder/component-test.yaml
+++ b/examples/patchbuilder/component-test.yaml
@@ -1,0 +1,47 @@
+componentFile: builder.yaml
+rootDirectory: './'
+testCases:
+- description: Success
+  build:
+    options:
+      ImageTag: '2.0'
+  apply:
+    options:
+      Namespace: default
+  expect:
+    findSubstrs:
+      Deployment-helloweb:
+      - 'namespace: default'
+      - 'image: gcr.io/google-samples/hello-app:2.0'
+      Service-helloweb:
+      - 'targetPort: 8080'
+
+- description: 'Success: change port'
+  build:
+    options:
+      ImageTag: '2.0'
+  apply:
+    options:
+      Namespace: default
+      Port: 8888
+  expect:
+    findSubstrs:
+      Deployment-helloweb:
+      - 'namespace: default'
+      - 'image: gcr.io/google-samples/hello-app:2.0'
+      Service-helloweb:
+      - 'targetPort: 8888'
+
+- description: 'Error: no image Tag'
+  apply:
+    options:
+      Namespace: default
+  expect:
+    buildErrSubstr: 'ImageTag in body is required'
+
+- description: 'Error: no namespace'
+  build:
+    options:
+      ImageTag: '2.0'
+  expect:
+    applyErrSubstr: 'Namespace in body is required'

--- a/examples/patchbuilder/component_test.go
+++ b/examples/patchbuilder/component_test.go
@@ -1,0 +1,25 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package patchbuilder
+
+import (
+	"testing"
+
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/testutil/componentsuite"
+)
+
+func TestComponentSuite(t *testing.T) {
+	componentsuite.Run(t, "component-test.yaml")
+}

--- a/pkg/build/BUILD.bazel
+++ b/pkg/build/BUILD.bazel
@@ -36,7 +36,7 @@ go_test(
         "inline_test.go",
         "patchbuild_test.go",
     ],
-    data = ["//examples:component_testdata"],
+    data = ["//examples:testdata"],
     embed = [":go_default_library"],
     deps = [
         "//pkg/apis/bundle/v1alpha1:go_default_library",

--- a/pkg/build/patchbuild.go
+++ b/pkg/build/patchbuild.go
@@ -78,8 +78,8 @@ func BuildPatchTemplate(ptb *bundle.PatchTemplateBuilder, opts options.JSONOptio
 	return pt, nil
 }
 
-// BuildComponentPatchTemplates iterates through all PatchTemplateBuilders in a Components Objects,
-// and converts them into PatchTemplates.
+// BuildComponentPatchTemplates iterates through all PatchTemplateBuilders in a
+// Components Objects, and converts them into PatchTemplates.
 func BuildComponentPatchTemplates(c *bundle.Component, fopts *filter.Options, opts options.JSONOptions) (*bundle.Component, error) {
 	ptbFilter := fopts
 	if ptbFilter == nil {

--- a/pkg/converter/BUILD.bazel
+++ b/pkg/converter/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = [
+        "bazel_init_test.go",
         "converter_integration_test.go",
         "converter_test.go",
         "decoder_test.go",
@@ -31,7 +32,7 @@ go_test(
         "name_test.go",
     ],
     data = [
-        "//examples:component_testdata",
+        "//examples:testdata",
     ],
     embed = [":go_default_library"],
     deps = [

--- a/pkg/testutil/componentsuite/BUILD.bazel
+++ b/pkg/testutil/componentsuite/BUILD.bazel
@@ -1,0 +1,33 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "componentsuite.go",
+        "schema.go",
+    ],
+    importpath = "github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/testutil/componentsuite",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/apis/bundle/v1alpha1:go_default_library",
+        "//pkg/build:go_default_library",
+        "//pkg/converter:go_default_library",
+        "//pkg/filter:go_default_library",
+        "//pkg/options:go_default_library",
+        "//pkg/options/patchtmpl:go_default_library",
+        "//pkg/testutil:go_default_library",
+        "//pkg/validate:go_default_library",
+        "//pkg/wrapper:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "bazel_init_test.go",
+        "componentsuite_test.go",
+    ],
+    data = ["//examples:testdata"],
+    embed = [":go_default_library"],
+    deps = ["//pkg/testutil:go_default_library"],
+)

--- a/pkg/testutil/componentsuite/bazel_init_test.go
+++ b/pkg/testutil/componentsuite/bazel_init_test.go
@@ -1,0 +1,23 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package componentsuite
+
+import (
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/testutil"
+)
+
+func init() {
+	testutil.ChangeToBazelDir("pkg/testutil/componentsuite")
+}

--- a/pkg/testutil/componentsuite/componentsuite.go
+++ b/pkg/testutil/componentsuite/componentsuite.go
@@ -1,0 +1,196 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package componentsuite provides a test-suite helper for running component tests.
+package componentsuite
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	bundle "github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/apis/bundle/v1alpha1"
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/build"
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/converter"
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/filter"
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/options/patchtmpl"
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/testutil"
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/validate"
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/wrapper"
+)
+
+// Run runs a component-tester test-suite. testSuiteFile specifies the path to
+// the current file.
+//
+// By default, go runs tests with the cwd being the current directory.
+func Run(t *testing.T, testSuiteFile string) {
+	t.Logf("Running tests for suite %q", testSuiteFile)
+
+	ctx := context.Background()
+
+	data, err := ioutil.ReadFile(testSuiteFile)
+	if err != nil {
+		t.Fatalf("while reading test suite file %q, %v", testSuiteFile, err)
+	}
+
+	ts := &ComponentTestSuite{}
+	if err := converter.FromFileName(testSuiteFile, data).ToObject(ts); err != nil {
+		t.Fatalf("while parsing test-suite file %q, %v", testSuiteFile, err)
+	}
+
+	os.Chdir(filepath.Join(filepath.Dir(testSuiteFile), ts.RootDirectory))
+
+	cdata, err := ioutil.ReadFile(ts.ComponentFile)
+	if err != nil {
+		t.Fatalf("while reading component file %q, %v", ts.ComponentFile, err)
+	}
+
+	bw, err := wrapper.FromRaw(string(converter.YAML), cdata)
+	if err != nil {
+		t.Fatalf("while converting component file %q, %v", ts.ComponentFile, err)
+	}
+
+	if bw.Kind() != "Component" && bw.Kind() != "ComponentBuilder" {
+		t.Fatalf("Got kind %q, but component kind must be \"Component\" or \"ComponentBuilder\"", bw.Kind())
+	}
+
+	var comp *bundle.Component
+	if bw.Kind() == "ComponentBuilder" {
+		inliner := build.NewLocalInliner(ts.RootDirectory)
+		comp, err = inliner.ComponentFiles(ctx, bw.ComponentBuilder())
+		if err != nil {
+		}
+	} else {
+		comp = bw.Component()
+	}
+
+	for _, tc := range ts.TestCases {
+		tci := tc // necessary.
+		t.Run(tc.Description, func(t *testing.T) {
+			t.Parallel()
+			runTest(t, comp.DeepCopy(), tci)
+		})
+	}
+}
+
+func runTest(t *testing.T, comp *bundle.Component, tc *TestCase) {
+	comp = runBuild(t, comp, tc)
+	if comp == nil {
+		return
+	}
+
+	comp = runApply(t, comp, tc)
+	if comp == nil {
+		return
+	}
+
+	runValidate(t, comp, tc)
+}
+
+func runBuild(t *testing.T, comp *bundle.Component, tc *TestCase) *bundle.Component {
+	buildFilter := &filter.Options{}
+	comp, err := build.BuildComponentPatchTemplates(comp, buildFilter, tc.Build.Options)
+	cerr := testutil.CheckErrorCases(err, tc.Expect.BuildErrSubstr)
+	if cerr != nil {
+		t.Fatal(cerr)
+	}
+	if err != nil {
+		// Since there's an error, it's a terminal condition. We can't proceed.
+		return nil
+	}
+	return comp
+}
+
+func runApply(t *testing.T, comp *bundle.Component, tc *TestCase) *bundle.Component {
+	applyOpts := &filter.Options{}
+	applyOpts.Annotations = tc.Apply.Filters
+
+	applier := patchtmpl.NewApplier(
+		patchtmpl.DefaultPatcherScheme(),
+		applyOpts,
+		true /* includeTemplates, for debugging */)
+
+	comp, err := applier.ApplyOptions(comp, tc.Apply.Options)
+	cerr := testutil.CheckErrorCases(err, tc.Expect.ApplyErrSubstr)
+	if cerr != nil {
+		t.Fatal(cerr)
+	}
+	if err != nil {
+		// Since there's an error, it's a terminal condition
+		return nil
+	}
+	return comp
+}
+
+func runValidate(t *testing.T, comp *bundle.Component, tc *TestCase) {
+	if errList := validate.Component(comp); len(errList) > 0 {
+		t.Errorf("There were errors validating component:\n%v", errList.ToAggregate())
+	}
+	objMap := make(map[string]string)
+	for _, obj := range comp.Spec.Objects {
+		matchFail := false
+		key := obj.GetKind()
+		if name := obj.GetName(); name != "" {
+			key = key + "-" + name
+		}
+
+		objStr, err := converter.FromObject(obj).ToYAMLString()
+		if err != nil {
+			// This is a very unlikely error.
+			t.Fatal(err)
+		}
+		objMap[key] = objStr
+
+		if tc.Expect.FindSubstrs != nil {
+			matchSubstrs := tc.Expect.FindSubstrs[key]
+			for _, expStr := range matchSubstrs {
+				if !strings.Contains(objStr, expStr) {
+					t.Errorf("Did not find %q in object %q, but expected to", expStr, key)
+					matchFail = true
+				}
+			}
+		}
+
+		if tc.Expect.FindSubstrs != nil {
+			notMatchSubstrs := tc.Expect.NotFindSubstrs[key]
+			for _, noExpStr := range notMatchSubstrs {
+				if strings.Contains(objStr, noExpStr) {
+					t.Errorf("Found %q in object %q, but did not expect to", noExpStr, key)
+					matchFail = true
+				}
+			}
+		}
+
+		if matchFail {
+			t.Errorf("Contents for object that didn't meet expectations %q:\n%s", key, objStr)
+		}
+	}
+
+	for key := range tc.Expect.FindSubstrs {
+		if _, ok := objMap[key]; !ok {
+			t.Errorf("Got object-keys %q, but expected to find object %q", stringMapKeys(objMap), key)
+		}
+	}
+}
+
+func stringMapKeys(m map[string]string) []string {
+	var out []string
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/pkg/testutil/componentsuite/componentsuite_test.go
+++ b/pkg/testutil/componentsuite/componentsuite_test.go
@@ -1,0 +1,23 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package componentsuite
+
+import (
+	"testing"
+)
+
+func TestComponentSuite(t *testing.T) {
+	Run(t, "../../../examples/patchbuilder/component-test.yaml")
+}

--- a/pkg/testutil/componentsuite/schema.go
+++ b/pkg/testutil/componentsuite/schema.go
@@ -1,0 +1,84 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package componentsuite
+
+import (
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/options"
+)
+
+// ComponentTestSuite contains metadata and test cases for running tests.
+type ComponentTestSuite struct {
+	// ComponentFile contains a path to a component file or component builder
+	// file.
+	ComponentFile string `json:componentFile`
+
+	// RootDirectory is the path to a root-directory.
+	RootDirectory string `json:rootDirectory`
+
+	// TestCases contains a list of component TestCases.
+	TestCases []*TestCase `json:testCases`
+}
+
+// TestCase contains the schema expected for the test-cases.
+type TestCase struct {
+	// Description of the test.
+	Description string `json:description`
+
+	// Build parameters
+	Build Build `json:build`
+
+	// Options-apply Parameters
+	Apply Apply `json:apply`
+
+	// Expectations to check
+	Expect Expect `json:expect`
+}
+
+// Build contains build parameters
+type Build struct {
+	// Options for the PatchTemplate build process
+	Options options.JSONOptions `json:options`
+
+	// Filters selects which patches to apply, based on the
+	// annotations on the patches.
+	Filters map[string]string `json:filters`
+}
+
+// Apply contains build paramaters
+type Apply struct {
+	// Options for apply process
+	Options options.JSONOptions `json:options`
+
+	// Filters selects which patches to apply, based on the
+	// annotations on the patches.
+	Filters map[string]string `json:filters`
+}
+
+// Expect contains expectations that should be filled.
+type Expect struct {
+	// Substrs contains a mapping from "<kind>-<objectname>" key to a list of substrings
+	// expected to be contained in the rendered object.
+	FindSubstrs map[string][]string `json:findSubstrs`
+
+	// NotFindSubstrs contains a mapping from "<kind>-<objectname>" to list of
+	// substrings that are not expected.
+	NotFindSubstrs map[string][]string `json:notFindSubstrs`
+
+	// BuildErrSubstr indicates a substring that's expected to be in an error in the build-process.
+	BuildErrSubstr string `json:buildErrSubstr`
+
+	// ApplyErrSubstr indicates a substring that's expected to be in an error in the apply-process.
+	ApplyErrSubstr string `json:applyErrSubstr`
+}

--- a/pkg/testutil/componentsuite/schema.go
+++ b/pkg/testutil/componentsuite/schema.go
@@ -68,17 +68,32 @@ type Apply struct {
 
 // Expect contains expectations that should be filled.
 type Expect struct {
-	// Substrs contains a mapping from "<kind>-<objectname>" key to a list of substrings
-	// expected to be contained in the rendered object.
-	FindSubstrs map[string][]string `json:findSubstrs`
+	// Objects contains expectations for objects.
+	Objects []ObjectCheck `json:objects`
 
-	// NotFindSubstrs contains a mapping from "<kind>-<objectname>" to list of
-	// substrings that are not expected.
-	NotFindSubstrs map[string][]string `json:notFindSubstrs`
-
-	// BuildErrSubstr indicates a substring that's expected to be in an error in the build-process.
+	// BuildErrSubstr indicates a substring that's expected to be in an error in
+	// the build-process.
 	BuildErrSubstr string `json:buildErrSubstr`
 
-	// ApplyErrSubstr indicates a substring that's expected to be in an error in the apply-process.
+	// ApplyErrSubstr indicates a substring that's expected to be in an error in
+	// the apply-process.
 	ApplyErrSubstr string `json:applyErrSubstr`
+}
+
+// ObjectCheck contains checks for an objects. Kind, and Name are used to find
+// objects. Expects exactly one object to match.
+type ObjectCheck struct {
+	// Kind of the objects (required).
+	Kind string `json:kind`
+
+	// Name of the objects (required).
+	Name string `json:name`
+
+	// FindSubstrs contains a list of substrings that are expecetd to be found in
+	// the object.
+	FindSubstrs []string `json:findSubstrs`
+
+	// NotFindSubstrs contains a list of substrings that are not expecetd to be
+	// found in the object
+	NotFindSubstrs []string `json:notFindSubstrs`
 }


### PR DESCRIPTION
Run component tests with `go test`, but define test cases in YAML!

Boiler plate looks like:

```go
package patchbuilder

import (
	"testing"

	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/testutil/componentsuite"
)

func TestComponentSuite(t *testing.T) {
	componentsuite.Run(t, "component-test.yaml")
}
```

Example test file:

```yaml
componentFile: builder.yaml
rootDirectory: './'
testCases:
- description: Success
  build:
    options:
      ImageTag: '2.0'
  apply:
    options:
      Namespace: default
  expect:
    findSubstrs:
      Deployment-helloweb:
      - 'namespace: default'
      - 'image: gcr.io/google-samples/hello-app:2.0'
      Service-helloweb:
      - 'targetPort: 8080'

- description: 'Error: no image Tag'
  apply:
    options:
      Namespace: default
  expect:
    buildErrSubstr: 'ImageTag in body is required'

```

Fixes: #175 