### PR TITLE
Clean up go lint and go vet warnings.

### DIFF
--- a/pkg/apis/bundle/v1alpha1/helpers_test.go
+++ b/pkg/apis/bundle/v1alpha1/helpers_test.go
@@ -43,8 +43,13 @@ func TestCreateName(t *testing.T) {
 }
 
 func TestGetLocalObjectRef(t *testing.T) {
-	ref := ComponentReference{"foo", "bar"}
-	exp := corev1.LocalObjectReference{"foo-bar"}
+	ref := ComponentReference{
+		ComponentName: "foo",
+		Version:       "bar",
+	}
+	exp := corev1.LocalObjectReference{
+		Name: "foo-bar",
+	}
 	if got := ref.GetLocalObjectRef(); got != exp {
 		t.Errorf("GetLocalObjectRef: got %s, but wanted %s", got, exp)
 	}
@@ -53,11 +58,15 @@ func TestGetLocalObjectRef(t *testing.T) {
 func TestGetAllLocalObjectRefs(t *testing.T) {
 	cset := ComponentSet{
 		Spec: ComponentSetSpec{
-			SetName:    "zip",
-			Components: []ComponentReference{{"foo", "1.2"}, {"biff", "2.3"}},
+			SetName: "zip",
+			Components: []ComponentReference{
+				{ComponentName: "foo", Version: "1.2"}, {ComponentName: "biff", Version: "2.3"}},
 		},
 	}
-	exp := []corev1.LocalObjectReference{{"foo-1.2"}, {"biff-2.3"}}
+	exp := []corev1.LocalObjectReference{
+		{Name: "foo-1.2"},
+		{Name: "biff-2.3"},
+	}
 	if got := cset.GetAllLocalObjectRefs(); !reflect.DeepEqual(got, exp) {
 		t.Errorf("GetAllLocalObjectRefs: got %v, but wanted %v", got, exp)
 	}
@@ -79,9 +88,12 @@ func TestMakeComponentReference(t *testing.T) {
 func TestMakeAndSetName_ComponentSet(t *testing.T) {
 	cset := ComponentSet{
 		Spec: ComponentSetSpec{
-			SetName:    "zip",
-			Version:    "1.2.3",
-			Components: []ComponentReference{{"foo", "1.2"}, {"biff", "2.3"}},
+			SetName: "zip",
+			Version: "1.2.3",
+			Components: []ComponentReference{
+				{ComponentName: "foo", Version: "1.2"},
+				{ComponentName: "biff", Version: "2.3"},
+			},
 		},
 	}
 	exp := "zip-1.2.3"

--- a/pkg/build/inline.go
+++ b/pkg/build/inline.go
@@ -43,7 +43,10 @@ type Inliner struct {
 func NewLocalInliner(cwd string) *Inliner {
 	return NewInlinerWithScheme(
 		files.FileScheme,
-		&files.LocalFileObjReader{filepath.Dir(cwd), &files.LocalFileSystemReader{}},
+		&files.LocalFileObjReader{
+			WorkingDir: filepath.Dir(cwd),
+			Rdr:        &files.LocalFileSystemReader{},
+		},
 	)
 }
 

--- a/pkg/build/patchbuild.go
+++ b/pkg/build/patchbuild.go
@@ -29,8 +29,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// BuildPatchTemplate renders a PatchTemplate from a PatchTemplateBuilder and options.
-func BuildPatchTemplate(ptb *bundle.PatchTemplateBuilder, opts options.JSONOptions) (*bundle.PatchTemplate, error) {
+// PatchTemplate renders a PatchTemplate from a PatchTemplateBuilder and options.
+func PatchTemplate(ptb *bundle.PatchTemplateBuilder, opts options.JSONOptions) (*bundle.PatchTemplate, error) {
 	name := ptb.GetName()
 	if ptb.Template == "" {
 		return nil, fmt.Errorf("cannot build PatchTemplate from PatchTemplateBuilder %q: it has an empty template", name)
@@ -77,9 +77,9 @@ func BuildPatchTemplate(ptb *bundle.PatchTemplateBuilder, opts options.JSONOptio
 	return pt, nil
 }
 
-// BuildComponentPatchTemplates iterates through all PatchTemplateBuilders in a
+// ComponentPatchTemplates iterates through all PatchTemplateBuilders in a
 // Components Objects, and converts them into PatchTemplates.
-func BuildComponentPatchTemplates(c *bundle.Component, fopts *filter.Options, opts options.JSONOptions) (*bundle.Component, error) {
+func ComponentPatchTemplates(c *bundle.Component, fopts *filter.Options, opts options.JSONOptions) (*bundle.Component, error) {
 	ptbFilter := fopts
 	if ptbFilter == nil {
 		ptbFilter = &filter.Options{}
@@ -99,7 +99,7 @@ func BuildComponentPatchTemplates(c *bundle.Component, fopts *filter.Options, op
 			return nil, err
 		}
 
-		pt, err := BuildPatchTemplate(&ptb, opts)
+		pt, err := PatchTemplate(&ptb, opts)
 		if err != nil {
 			return nil, err
 		}
@@ -117,12 +117,12 @@ func BuildComponentPatchTemplates(c *bundle.Component, fopts *filter.Options, op
 	return c, nil
 }
 
-// BuildAllPatchTemplates is a convenience method to build all PatchTemplateBuilders into
+// AllPatchTemplates is a convenience method to build all PatchTemplateBuilders into
 // PatchTemplates for all Components in a Bundle.
-func BuildAllPatchTemplates(bw *wrapper.BundleWrapper, fopts *filter.Options, opts options.JSONOptions) (*wrapper.BundleWrapper, error) {
+func AllPatchTemplates(bw *wrapper.BundleWrapper, fopts *filter.Options, opts options.JSONOptions) (*wrapper.BundleWrapper, error) {
 	switch bw.Kind() {
 	case "Component":
-		comp, err := BuildComponentPatchTemplates(bw.Component(), fopts, opts)
+		comp, err := ComponentPatchTemplates(bw.Component(), fopts, opts)
 		if err != nil {
 			return nil, err
 		}
@@ -131,7 +131,7 @@ func BuildAllPatchTemplates(bw *wrapper.BundleWrapper, fopts *filter.Options, op
 		bun := bw.Bundle()
 		var comps []*bundle.Component
 		for _, comp := range bun.Components {
-			comp, err := BuildComponentPatchTemplates(comp, fopts, opts)
+			comp, err := ComponentPatchTemplates(comp, fopts, opts)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/build/patchbuild_test.go
+++ b/pkg/build/patchbuild_test.go
@@ -363,7 +363,7 @@ spec:
 				t.Fatalf("Error converting component %s: %v", tc.component, err)
 			}
 
-			newComp, err := BuildComponentPatchTemplates(c, tc.customFilter, tc.opts)
+			newComp, err := ComponentPatchTemplates(c, tc.customFilter, tc.opts)
 			cerr := testutil.CheckErrorCases(err, tc.expErrSubstr)
 			if cerr != nil {
 				t.Error(cerr)

--- a/pkg/commands/build/build.go
+++ b/pkg/commands/build/build.go
@@ -70,7 +70,7 @@ func run(ctx context.Context, o *options, brw cmdlib.BundleReaderWriter, rw file
 		return err
 	}
 
-	bw, err = build.BuildAllPatchTemplates(bw, &filter.Options{}, buildOpts)
+	bw, err = build.AllPatchTemplates(bw, &filter.Options{}, buildOpts)
 	if err != nil {
 		return err
 	}

--- a/pkg/commands/cmdlib/bundleio.go
+++ b/pkg/commands/cmdlib/bundleio.go
@@ -38,8 +38,10 @@ type makeInliner func(rw files.FileReaderWriter, inputFile string) fileInliner
 func realInlinerMaker(rw files.FileReaderWriter, inputFile string) fileInliner {
 	return build.NewInlinerWithScheme(
 		files.FileScheme,
-		&files.LocalFileObjReader{filepath.Dir(inputFile), rw},
-	)
+		&files.LocalFileObjReader{
+			WorkingDir: filepath.Dir(inputFile),
+			Rdr:        rw,
+		})
 }
 
 // StdioReaderWriter can read from STDIN and write to STDOUT.

--- a/pkg/filter/filter.go
+++ b/pkg/filter/filter.go
@@ -112,8 +112,8 @@ func (f *Filter) Objects(data []*unstructured.Unstructured, o *Options) []*unstr
 	return notMatched
 }
 
-// PartitionObjects splits the objects into matched and not matched sets. As a
-// detail, PartitionObjects ignores the KeepOnly option, since both matched and
+// PartitionObjects splits the objects into matched and not matched sets.
+// PartitionObjects ignores the KeepOnly option, since both matched and
 // unmatched objects are returned. Thus, the options to partition are always
 // treated as options for matching objects.
 func (f *Filter) PartitionObjects(data []*unstructured.Unstructured, o *Options) ([]*unstructured.Unstructured, []*unstructured.Unstructured) {

--- a/pkg/filter/filter.go
+++ b/pkg/filter/filter.go
@@ -99,10 +99,9 @@ func (f *Filter) Components(data []*bundle.Component, o *Options) []*bundle.Comp
 	return notMatched
 }
 
-// Objects filters objects based on the ObjectMeta properties of
-// the objects, returning a new list with just filtered
-// objects. By default objects are removed, unless KeepOnly is set, and
-// then the opposite is true.
+// Objects filters objects based on the ObjectMeta properties of the objects,
+// returning a new list with just filtered objects. By default objects are
+// removed, unless KeepOnly is set, and then the opposite is true.
 func (f *Filter) Objects(data []*unstructured.Unstructured, o *Options) []*unstructured.Unstructured {
 	matched, notMatched := f.PartitionObjects(data, o)
 
@@ -113,8 +112,10 @@ func (f *Filter) Objects(data []*unstructured.Unstructured, o *Options) []*unstr
 	return notMatched
 }
 
-// TODO(jhoak): test for this
-// PartitionObjects splits the objects into matched and not matched sets.
+// PartitionObjects splits the objects into matched and not matched sets. As a
+// detail, PartitionObjects ignores the KeepOnly option, since both matched and
+// unmatched objects are returned. Thus, the options to partition are always
+// treated as options for matching objects.
 func (f *Filter) PartitionObjects(data []*unstructured.Unstructured, o *Options) ([]*unstructured.Unstructured, []*unstructured.Unstructured) {
 	if !f.ChangeInPlace {
 		var newData []*unstructured.Unstructured

--- a/pkg/find/images_test.go
+++ b/pkg/find/images_test.go
@@ -58,7 +58,10 @@ func TestImageFinder_Found(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	key := bundle.ComponentReference{"foo", "bar"}
+	key := bundle.ComponentReference{
+		ComponentName: "foo",
+		Version:       "X.Y",
+	}
 
 	expkey := core.ClusterObjectKey{
 		Component: key,
@@ -110,7 +113,10 @@ func TestImageFinder_NotFound(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	key := bundle.ComponentReference{"foo", "biff"}
+	key := bundle.ComponentReference{
+		ComponentName: "foo",
+		Version:       "100.3",
+	}
 	f := ImageFinder{}
 	found := f.ContainerImages(key, s)
 	if len(found) != 0 {
@@ -142,7 +148,10 @@ func TestImageFinder_MultipleImages(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	key := bundle.ComponentReference{"gloo", "logger"}
+	key := bundle.ComponentReference{
+		ComponentName: "gloo",
+		Version:       "1.0",
+	}
 	expkey := core.ClusterObjectKey{
 		Component: key,
 		Object: core.ObjectRef{

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -26,8 +26,6 @@ import (
 	bundle "github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/apis/bundle/v1alpha1"
 )
 
-// TODO(kashomon): Should options be of JSON Type or just interface{}?
-
 // JSONOptions is an instance of options, represented as a JSON object encoded
 // as map[string]interface{}. See more at the go docs for `encoding/json`.
 type JSONOptions map[string]interface{}
@@ -40,8 +38,18 @@ type Applier interface {
 }
 
 const (
-	MissingKeyError   = "missingkey=error"
+	// MissingKeyError is an option for go templates. Execution stops immediately
+	// with an error. This is the used as the default in the ClusterBundle.
+	MissingKeyError = "missingkey=error"
+
+	// MissingKeyDefault is same as MissingKeyInvalid.
 	MissingKeyDefault = "missingkey=default"
+
+	// MissingKeyInvalid ihe default behavior: Do nothing and continue execution.
+	// If printed, the result of the index operation is the string
 	MissingKeyInvalid = "missingkey=invalid"
-	MissingKeyZero    = "missingkey=zero"
+
+	// MissingKeyZero is an option for go templates. The operation returns the
+	// zero value for the map type's element.
+	MissingKeyZero = "missingkey=zero"
 )

--- a/pkg/options/rawyamltmpl/raw_text_applier_test.go
+++ b/pkg/options/rawyamltmpl/raw_text_applier_test.go
@@ -99,7 +99,7 @@ func TestRawStringApplier_MultiItems(t *testing.T) {
 		t.Fatalf("no objects found in new component")
 	}
 
-	strval, err := (&converter.ObjectExporter{newComp.Spec.Objects}).ExportAsYAML()
+	strval, err := (&converter.ObjectExporter{Objects: newComp.Spec.Objects}).ExportAsYAML()
 	if err != nil {
 		t.Fatalf("Error converting objects to yaml: %v", err)
 	}

--- a/pkg/options/simpletemplate/simple_applier_test.go
+++ b/pkg/options/simpletemplate/simple_applier_test.go
@@ -75,7 +75,7 @@ func TestSimpleApplier(t *testing.T) {
 		t.Fatalf("no objects found in new component")
 	}
 
-	strval, err := (&converter.ObjectExporter{newComp.Spec.Objects}).ExportAsYAML()
+	strval, err := (&converter.ObjectExporter{Objects: newComp.Spec.Objects}).ExportAsYAML()
 	if err != nil {
 		t.Fatalf("Error converting objects to yaml: %v", err)
 	}
@@ -159,7 +159,7 @@ func TestSimpleApplier_MultiItems(t *testing.T) {
 		t.Fatalf("no objects found in new component")
 	}
 
-	strval, err := (&converter.ObjectExporter{newComp.Spec.Objects}).ExportAsYAML()
+	strval, err := (&converter.ObjectExporter{Objects: newComp.Spec.Objects}).ExportAsYAML()
 	if err != nil {
 		t.Fatalf("Error converting objects to yaml: %v", err)
 	}

--- a/pkg/testutil/componentsuite/componentsuite.go
+++ b/pkg/testutil/componentsuite/componentsuite.go
@@ -104,7 +104,7 @@ func runTest(t *testing.T, comp *bundle.Component, tc *TestCase) {
 
 func runBuild(t *testing.T, comp *bundle.Component, tc *TestCase) *bundle.Component {
 	buildFilter := &filter.Options{}
-	comp, err := build.BuildComponentPatchTemplates(comp, buildFilter, tc.Build.Options)
+	comp, err := build.ComponentPatchTemplates(comp, buildFilter, tc.Build.Options)
 	cerr := testutil.CheckErrorCases(err, tc.Expect.BuildErrSubstr)
 	if cerr != nil {
 		t.Fatal(cerr)

--- a/pkg/testutil/componentsuite/schema.go
+++ b/pkg/testutil/componentsuite/schema.go
@@ -22,80 +22,80 @@ import (
 type ComponentTestSuite struct {
 	// ComponentFile contains a path to a component file or component builder
 	// file.
-	ComponentFile string `json:componentFile`
+	ComponentFile string `json:"componentFile"`
 
 	// RootDirectory is the path to a root-directory.
-	RootDirectory string `json:rootDirectory`
+	RootDirectory string `json:"rootDirectory"`
 
 	// TestCases contains a list of component TestCases.
-	TestCases []*TestCase `json:testCases`
+	TestCases []*TestCase `json:"testCases"`
 }
 
 // TestCase contains the schema expected for the test-cases.
 type TestCase struct {
 	// Description of the test.
-	Description string `json:description`
+	Description string `json:"description"`
 
 	// Build contains parameters for the build-phase. This is roughly equivalent
 	// to 'bundlectl build'
-	Build Build `json:build`
+	Build Build `json:"build"`
 
 	// Apply contains parameters for the apply-phase. This is roughly equivalent
 	// to 'bundlectl apply'
-	Apply Apply `json:apply`
+	Apply Apply `json:"apply"`
 
 	// Expect contains expectations to check against.
-	Expect Expect `json:expect`
+	Expect Expect `json:"expect"`
 }
 
 // Build contains build parameters
 type Build struct {
 	// Options for the PatchTemplate build process
-	Options options.JSONOptions `json:options`
+	Options options.JSONOptions `json:"options"`
 
 	// Filters selects which patches to apply, based on the
 	// annotations on the patches.
-	Filters map[string]string `json:filters`
+	Filters map[string]string `json:"filters"`
 }
 
 // Apply contains build paramaters
 type Apply struct {
 	// Options for apply process
-	Options options.JSONOptions `json:options`
+	Options options.JSONOptions `json:"options"`
 
 	// Filters selects which patches to apply, based on the
 	// annotations on the patches.
-	Filters map[string]string `json:filters`
+	Filters map[string]string `json:"filters"`
 }
 
 // Expect contains expectations that should be filled.
 type Expect struct {
 	// Objects contains expectations for objects.
-	Objects []ObjectCheck `json:objects`
+	Objects []ObjectCheck `json:"objects"`
 
 	// BuildErrSubstr indicates a substring that's expected to be in an error in
 	// the build-process.
-	BuildErrSubstr string `json:buildErrSubstr`
+	BuildErrSubstr string `json:"buildErrSubstr"`
 
 	// ApplyErrSubstr indicates a substring that's expected to be in an error in
 	// the apply-process.
-	ApplyErrSubstr string `json:applyErrSubstr`
+	ApplyErrSubstr string `json:"applyErrSubstr"`
 }
 
 // ObjectCheck contains checks for a specific Object. Kind, and Name are used to find
 // objects. Expects exactly one object to match.
 type ObjectCheck struct {
-	// Kind of the objects (required).
-	Kind string `json:kind`
+	// Kind of the object (required).
+	Kind string `json:"kind"`
 
-	// Name of the objects (required).
-	Name string `json:name`
+	// Name of the object (required).
+	Name string `json:"name"`
 
 	// FindSubstrs contains a list of substrings that are expected to be found in
 	// the object after the apply-phase.
-	FindSubstrs []string `json:findSubstrs`
+	FindSubstrs []string `json:"findSubstrs"`
 
 	// NotFindSubstrs contains a list of substrings that are not expecetd to be
 	// found in the object after the apply-phase.
-	NotFindSubstrs []string `json:notFindSubstrs`
+	NotFindSubstrs []string `json:"notFindSubstrs"`
 }


### PR DESCRIPTION
- Fix some bad JSON tags in componentsuite.go
- Rename `build.BuildPatchTemplates` to `build.PatchTemplates` (and variants) to fix stutter
- Fix comment for filter.Partition and add a test
- Add comments for the template options in pkg/options
- Fix several unkeyed structs.