### PR TITLE
Add build tags + an exporter for components that writes to paths.

### DIFF
--- a/examples/cluster/datablob/data-blob-component.yaml
+++ b/examples/cluster/datablob/data-blob-component.yaml
@@ -20,3 +20,5 @@ rawTextFiles:
 - name: data-blob
   files:
   - url: file:///datablob/some-data.txt
+buildTags:
+- latest

--- a/examples/cluster/kubernetes/kubernetes-component.yaml
+++ b/examples/cluster/kubernetes/kubernetes-component.yaml
@@ -20,3 +20,5 @@ objectFiles:
 - url: file:///kubernetes/kube-apiserver.yaml
 - url: file:///kubernetes/kube-scheduler.yaml
 - url: file:///kubernetes/kube-controller-manager.yaml
+buildTags:
+- stable

--- a/pkg/apis/bundle/v1alpha1/builder_types.go
+++ b/pkg/apis/bundle/v1alpha1/builder_types.go
@@ -91,6 +91,15 @@ type ComponentBuilder struct {
 	// inline process, the data is inserted into a generated config map before
 	// being added to the objects. A ConfigMap is generated per-filegroup.
 	RawTextFiles []FileGroup `json:"rawTextFiles,omitempty"`
+
+	// BuildTags are tags to apply to the component during component-build time.
+	// The primary purpose of BuildTags is so that built-components can be
+	// exported to specific directories. It is stored as a comma-separated value
+	// in an annotation on the built-component.
+	//
+	// Build-tags should follow the same rules as Kubernetes names. See
+	// https://kubernetes.io/docs/concepts/overview/working-with-objects/names/
+	BuildTags []string `json:"buildTags,omitempty"`
 }
 
 // FileGroup represents a collection of files. When used to create ConfigMaps

--- a/pkg/apis/bundle/v1alpha1/identifiers.go
+++ b/pkg/apis/bundle/v1alpha1/identifiers.go
@@ -22,6 +22,9 @@ const (
 	// InlineTypeIdentifier is an identifier used to identify how an object in a
 	// component was inlined.
 	InlineTypeIdentifier Identifier = "bundle.gke.io/inline-type"
+
+	// BuildTagIdentifier is an identifier used for creating build tags.
+	BuildTagIdentifier = "bundle.gke.io/build-tags"
 )
 
 // InlineType is a value that the InlineTypeIdentifier can take.

--- a/pkg/build/inline.go
+++ b/pkg/build/inline.go
@@ -165,6 +165,15 @@ func (n *Inliner) ComponentFiles(ctx context.Context, comp *bundle.ComponentBuil
 		return nil, fmt.Errorf("metadata.Name %q is not a valid DNS 1123 subdomain in component %q/%q: %v",
 			om.Name, comp.ComponentName, comp.Version, errs)
 	}
+
+	if len(comp.BuildTags) > 0 {
+		tagString := strings.Join(comp.BuildTags, ",")
+		if om.Annotations == nil {
+			om.Annotations = make(map[string]string)
+		}
+		om.Annotations[bundle.BuildTagIdentifier] = tagString
+	}
+
 	newComp := &bundle.Component{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "bundle.gke.io/v1alpha1",

--- a/pkg/commands/export/BUILD.bazel
+++ b/pkg/commands/export/BUILD.bazel
@@ -3,15 +3,18 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = [
-        "export.go",
+        "component_export.go",
         "get_command.go",
+        "object_export.go",
     ],
     importpath = "github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/commands/export",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/apis/bundle/v1alpha1:go_default_library",
         "//pkg/commands/cmdlib:go_default_library",
         "//pkg/converter:go_default_library",
         "//pkg/files:go_default_library",
+        "//pkg/wrapper:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],

--- a/pkg/commands/export/component_export.go
+++ b/pkg/commands/export/component_export.go
@@ -1,0 +1,133 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package export
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	bundle "github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/apis/bundle/v1alpha1"
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/commands/cmdlib"
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/converter"
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/files"
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/wrapper"
+	log "k8s.io/klog"
+)
+
+// pathTemplates are go-template paths to indicate how and where to generate
+// component files.  Possible values are {ComponentName, Version, BuildTag,
+// SetName}.  Only applies when the write-to flag is also set.
+var pathTemplates = []string{
+	"{{.ComponentName}}/{{.ComponentName}}-{{.Version}}.yaml",
+	"{{.ComponentName}}/{{.BuildTag}}/{{.ComponentName}}.yaml",
+	"sets/{{.SetName}}-{{.Version}}.yaml",
+}
+
+const defaultPerms = 0664
+
+// compOptions represents options flags for the export command.
+type compOptions struct {
+	// writeTo indicates the directory to write the components to. This is joined with the pa
+	writeTo string
+
+	// overwrite indicates whether to overwrite existing files.
+	overwrite bool
+
+	// exportSet determines whether to export a set for all the known components.
+	exportSet bool
+
+	// setName is an optional set name for the set of components.
+	setName string
+
+	// version is an optional version for the components
+	setVersion string
+}
+
+func componentAction(ctx context.Context, fio files.FileReaderWriter, sio cmdlib.StdioReaderWriter, o *compOptions, gopts *cmdlib.GlobalOptions) {
+	brw := cmdlib.NewBundleReaderWriter(fio, sio)
+	if err := runComponent(ctx, brw, sio, fio, o, gopts); err != nil {
+		log.Exit(err)
+	}
+}
+
+func runComponent(ctx context.Context, brw cmdlib.BundleReaderWriter, stdio cmdlib.StdioReaderWriter, fio files.FileReaderWriter, o *compOptions, gopt *cmdlib.GlobalOptions) error {
+	bw, err := brw.ReadBundleData(ctx, gopt)
+	if err != nil {
+		return fmt.Errorf("error reading bundle contents: %v", err)
+	}
+
+	comps := bw.AllComponents()
+
+	var set *bundle.ComponentSet
+	if o.exportSet {
+		setName, setVersion := getSetNameVersion(bw, o)
+		set, err = converter.NewExporter(comps...).ComponentSet(setName, setVersion)
+		if err != nil {
+			return err
+		}
+	}
+
+	if o.writeTo != "" {
+		return writeToFiles(ctx, comps, o, fio, set)
+	} else {
+		return writeToStdout(comps, stdio, set)
+	}
+}
+
+func getSetNameVersion(bw *wrapper.BundleWrapper, o *compOptions) (string, string) {
+	setName := o.setName
+	setVersion := o.setVersion
+	if bw.Kind() == "bundle" {
+		bun := bw.Bundle()
+		setName = bun.SetName
+		setVersion = bun.Version
+	}
+	return setName, setVersion
+}
+
+func writeToFiles(ctx context.Context, comps []*bundle.Component, o *compOptions, fio files.FileReaderWriter, set *bundle.ComponentSet) error {
+	pathMap, err := converter.NewExporter(comps...).ComponentsWithPathTemplates(pathTemplates, set)
+	if err != nil {
+		return err
+	}
+	for cpath, yaml := range pathMap {
+		fpath := filepath.Join(o.writeTo, cpath)
+		dir := filepath.Dir(fpath)
+		// TODO(kashomon): This is going to be a problem for mocking.
+		if _, err := os.Stat(dir); os.IsNotExist(err) {
+			os.MkdirAll(dir, os.ModePerm)
+		}
+		if !o.overwrite {
+			if _, err := os.Stat(fpath); err == nil {
+				return fmt.Errorf("file %q already exists", fpath)
+			}
+		}
+		if err := fio.WriteFile(ctx, fpath, []byte(yaml), defaultPerms); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeToStdout(comps []*bundle.Component, stdio cmdlib.StdioReaderWriter, set *bundle.ComponentSet) error {
+	data, err := converter.NewExporter(comps...).ComponentsAsSingleYAML(set)
+	if err != nil {
+		return err
+	}
+	_, err = stdio.Write([]byte(data))
+	return err
+}

--- a/pkg/commands/export/get_command.go
+++ b/pkg/commands/export/get_command.go
@@ -23,16 +23,47 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// GetCommand returns the command for exporting.
+// GetCommand returns the export command.
 func GetCommand(ctx context.Context, fio files.FileReaderWriter, sio cmdlib.StdioReaderWriter, gopts *cmdlib.GlobalOptions) *cobra.Command {
-	opts := &options{}
 	cmd := &cobra.Command{
 		Use:   "export",
+		Short: "Exports components or objects",
+		Long:  `Exports components or objects. See subcommands for usage`,
+	}
+
+	objOpts := &objOptions{}
+	objectCmd := &cobra.Command{
+		Use:   "objects",
 		Short: "Exports all of the objects",
 		Long:  `Exports all objects to STDOUT as YAML delimited by ---`,
 		Run: func(cmd *cobra.Command, args []string) {
-			action(ctx, fio, sio, cmd, opts, gopts)
+			objectAction(ctx, fio, sio, objOpts, gopts)
 		},
 	}
+
+	compOpts := &compOptions{}
+	componentCmd := &cobra.Command{
+		Use:   "components",
+		Short: "Exports all of the components",
+		Long:  `Exports all of the components, to STDOUT or to files.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			componentAction(ctx, fio, sio, compOpts, gopts)
+		},
+	}
+
+	componentCmd.Flags().StringVar(&compOpts.writeTo, "write-to", "",
+		"Directory to write the components to. If not set, writes to STDOUT, delimited by ---")
+	componentCmd.Flags().BoolVar(&compOpts.overwrite, "overwrite", false,
+		"Whether to overwrite files. By default, if a file already exists, an error will be produced.")
+
+	componentCmd.Flags().BoolVar(&compOpts.exportSet, "export-set", false,
+		"Whether to export a component set when exporting components.")
+	componentCmd.Flags().StringVar(&compOpts.setName, "setName", "component-set",
+		"name for the component set, if not specified by a bundle")
+	componentCmd.Flags().StringVar(&compOpts.setVersion, "setVersion", "0.1.0",
+		"version for the component set, if not specified by a bundle")
+
+	cmd.AddCommand(objectCmd)
+	cmd.AddCommand(componentCmd)
 	return cmd
 }

--- a/pkg/commands/export/object_export.go
+++ b/pkg/commands/export/object_export.go
@@ -22,32 +22,25 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/converter"
 	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/files"
 	log "k8s.io/klog"
-	"github.com/spf13/cobra"
 )
 
-// options represents options flags for the export command.
-type options struct{}
+// objOptions represents options flags for the export objects command.
+type objOptions struct{}
 
-func action(ctx context.Context, fio files.FileReaderWriter, sio cmdlib.StdioReaderWriter, cmd *cobra.Command,  opts *options, gopt *cmdlib.GlobalOptions) {
+func objectAction(ctx context.Context, fio files.FileReaderWriter, sio cmdlib.StdioReaderWriter, _ *objOptions, gopt *cmdlib.GlobalOptions) {
 	brw := cmdlib.NewBundleReaderWriter(fio, sio)
-	if err := run(ctx, opts, brw, sio, gopt); err != nil {
+	if err := runObject(ctx, brw, sio, gopt); err != nil {
 		log.Exit(err)
 	}
 }
 
-func run(ctx context.Context, o *options, brw cmdlib.BundleReaderWriter, stdio cmdlib.StdioReaderWriter, gopt *cmdlib.GlobalOptions) error {
+func runObject(ctx context.Context, brw cmdlib.BundleReaderWriter, stdio cmdlib.StdioReaderWriter, gopt *cmdlib.GlobalOptions) error {
 	bw, err := brw.ReadBundleData(ctx, gopt)
 	if err != nil {
 		return fmt.Errorf("error reading bundle contents: %v", err)
 	}
 
-	objs, err := bw.ExportAsObjects()
-	if err != nil {
-		return err
-	}
-
-	exporter := converter.ObjectExporter{Objects: objs}
-	s, err := exporter.ExportAsYAML()
+	s, err := converter.NewExporter(bw.AllComponents()...).ObjectsAsSingleYAML()
 	if err != nil {
 		return err
 	}

--- a/pkg/converter/BUILD.bazel
+++ b/pkg/converter/BUILD.bazel
@@ -36,6 +36,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//pkg/apis/bundle/v1alpha1:go_default_library",
         "//pkg/testutil:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",
     ],

--- a/pkg/converter/exporter.go
+++ b/pkg/converter/exporter.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC
+// Copyright 2018-2019 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,46 +15,228 @@
 package converter
 
 import (
+	"bytes"
+	"errors"
+	"fmt"
 	"strings"
+	"text/template"
 
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	bundle "github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/apis/bundle/v1alpha1"
 )
 
-// ObjectExporter exports cluster objects
-type ObjectExporter struct {
-	Objects []*unstructured.Unstructured
+// Exporter exports cluster objects and components in forms other than just
+// basic serialized yaml.
+type Exporter struct {
+	comps []*bundle.Component
 }
 
-// ExportAsMultiYAML converts cluster objects into multiple YAML files.
-func (e *ObjectExporter) ExportAsMultiYAML() ([]string, error) {
+// NewExporter creates a new exporter Object
+func NewExporter(comps ...*bundle.Component) *Exporter {
+	return &Exporter{comps}
+}
+
+// ObjectsAsMultiYAML converts cluster objects into multiple YAML files.
+func (e *Exporter) ObjectsAsMultiYAML() ([]string, error) {
 	var out []string
 	var empty []string
-	for _, o := range e.Objects {
-		yaml, err := FromObject(o).ToYAML()
-		if err != nil {
-			return empty, err
+	for _, c := range e.comps {
+		for _, o := range c.Spec.Objects {
+			yaml, err := FromObject(o).ToYAML()
+			if err != nil {
+				return empty, err
+			}
+			out = append(out, string(yaml))
 		}
-		out = append(out, string(yaml))
 	}
 	return out, nil
 }
 
-// ExportAsYAML converts cluster objects into single YAML file.
-func (e *ObjectExporter) ExportAsYAML() (string, error) {
-	numElements := len(e.Objects)
+// ObjectsAsYAML converts cluster objects into single YAML file.
+func (e *Exporter) ObjectsAsSingleYAML() (string, error) {
 	var sb strings.Builder
-	for i, o := range e.Objects {
-		yaml, err := FromObject(o).ToYAML()
-		if err != nil {
-			return "", err
-		}
-		sb.Write(yaml)
-		if i < numElements-1 {
-			// Join the objects into one document.
-			// Note: Each doc ends with a newline (from the ToYAML step), so we don't
-			// need to write an additional newline
-			sb.WriteString("---\n")
+	numComp := len(e.comps)
+	for j, c := range e.comps {
+		numObj := len(c.Spec.Objects)
+		for i, o := range c.Spec.Objects {
+			yaml, err := FromObject(o).ToYAML()
+			if err != nil {
+				return "", err
+			}
+			sb.Write(yaml)
+			if i < numObj-1 || j < numComp-1 {
+				// Join the objects into one document.
+				// Note: Each doc ends with a newline (from the ToYAML step), so we don't
+				// need to write an additional newline
+				sb.WriteString("---\n")
+			}
 		}
 	}
 	return sb.String(), nil
+}
+
+// ComponentSet creates a component set with the given name and version.
+func (e *Exporter) ComponentSet(setName, setVersion string) (*bundle.ComponentSet, error) {
+	if setName == "" {
+		return nil, errors.New("set name is required to export ComponentSet, but was empty")
+	}
+	if setVersion == "" {
+		return nil, errors.New("set version is required to export ComponentSet, but was empty")
+	}
+	newBun := &bundle.Bundle{
+		SetName:    setName,
+		Version:    setVersion,
+		Components: e.comps,
+	}
+	return newBun.ComponentSet(), nil
+}
+
+// ComponentsAsSingleYAML creates a single YAML file, delimited by '---'. If
+// a component set is defined, the component set is append to the end.
+func (e *Exporter) ComponentsAsSingleYAML(set *bundle.ComponentSet) (string, error) {
+	var sb strings.Builder
+	for i, c := range e.comps {
+		cyaml, err := FromObject(c).ToYAML()
+		if err != nil {
+			return "", fmt.Errorf("while rendering component %v: %v", c.ComponentReference(), err)
+		}
+		sb.Write(cyaml)
+		if i < len(e.comps)-1 {
+			sb.WriteString("---\n")
+		}
+	}
+	if set != nil {
+		sb.WriteString("---\n")
+		cyaml, err := FromObject(set).ToYAML()
+		if err != nil {
+			return "", fmt.Errorf("while rendering component set: %v", err)
+		}
+		sb.Write(cyaml)
+	}
+	return sb.String(), nil
+}
+
+// ComponentsWithPathTemplates takes in a set of pathTemplates and an optional
+// set, and produces a map of paths to YAML files.
+//
+// pathTemplates are template strings and must be a templated filePath. The
+// optional values are
+//
+// - ComponentName: name of component
+// - Version: version of the component or component set
+// - BuildTag: build tag for the component
+// - SetName: name of the component set
+//
+// For example, here are same possible ways to craft pathTemplates
+//
+//   "{{.ComponentName}}/{{.Version}}/{{.ComponentName}}-{{.Version}}.yaml",
+//   "{{.ComponentName}}/{{.BuildTag}}/{{.ComponentName}}.yaml",
+//   "sets/{{.SetName}}-{{.Version}}.yaml",
+func (e *Exporter) ComponentsWithPathTemplates(pathTemplates []string, set *bundle.ComponentSet) (map[string]string, error) {
+	var tmpls []*template.Template
+	for i, tmplstr := range pathTemplates {
+		tmpl, err := template.New(fmt.Sprintf("template-%d", i)).Parse(tmplstr)
+		if err != nil {
+			return nil, fmt.Errorf("while parsing path template %q: %v", tmplstr, err)
+		}
+		tmpls = append(tmpls, tmpl)
+	}
+
+	outMap := make(map[string]string)
+	for _, comp := range e.comps {
+		cyaml, err := FromObject(comp).ToYAMLString()
+		if err != nil {
+			return nil, fmt.Errorf("while rendering component %v: %v", comp.ComponentReference(), err)
+		}
+		vals := makeValuesForPathTemplates(comp)
+		pmap, err := makePathMap(cyaml, tmpls, vals)
+		if err != nil {
+			return nil, err
+		}
+		// Merge the values into a single map
+		for k, val := range pmap {
+			outMap[k] = val
+		}
+	}
+
+	if set != nil {
+		// TODO(kashomon): Could/should sets have BuildTags?
+		setVals := []map[string]string{
+			map[string]string{
+				"SetName": set.Spec.SetName,
+				"Version": set.Spec.Version,
+			},
+		}
+		setYaml, err := FromObject(set).ToYAMLString()
+		if err != nil {
+			return nil, fmt.Errorf("while rendering set: %v", err)
+		}
+		pmap, err := makePathMap(setYaml, tmpls, setVals)
+		if err != nil {
+			return nil, err
+		}
+		for k, val := range pmap {
+			outMap[k] = val
+		}
+	}
+	return outMap, nil
+}
+
+// makeValuesForPathTemplates creates a map of string-to-string for inserting
+// values into the pathTemplates.
+//
+// Currently it creates a map with three keys.
+//
+// - ComponentName: name of component
+// - Version: version of the component or component set
+// - BuildTag: build tag for the component.
+//
+// If Version is specified, BuildTag will not be specified. Hence, if the
+// component has a versiona nd three build tags, four values-maps will be
+// generated, one for each of the build tags and one for the version.
+//
+// Additionally, ComponentName and Version will never be specified if SetName
+// and SetVersion are also specified.
+func makeValuesForPathTemplates(comp *bundle.Component) []map[string]string {
+	values := []map[string]string{
+		map[string]string{
+			"ComponentName": comp.Spec.ComponentName,
+			"Version":       comp.Spec.Version,
+		},
+	}
+
+	// Create more values if there are any build tags.
+	if comp.ObjectMeta.Annotations != nil &&
+		comp.ObjectMeta.Annotations[bundle.BuildTagIdentifier] != "" {
+		tagString := comp.ObjectMeta.Annotations[bundle.BuildTagIdentifier]
+		splitTags := strings.Split(tagString, ",")
+		for _, tag := range splitTags {
+			values = append(values, map[string]string{
+				"ComponentName": comp.Spec.ComponentName,
+				"BuildTag":      tag,
+				"Version":       comp.Spec.Version,
+			})
+		}
+	}
+	return values
+}
+
+func makePathMap(comp string, templates []*template.Template, values []map[string]string) (map[string]string, error) {
+	pathMap := make(map[string]string)
+	var paths []string
+	for _, vals := range values {
+		for _, pathTmpl := range templates {
+			var doc bytes.Buffer
+			if err := pathTmpl.Execute(&doc, vals); err != nil {
+				return nil, err
+			}
+			str := doc.String()
+			if !strings.Contains(str, "<no value>") {
+				paths = append(paths, str)
+			}
+		}
+	}
+	for _, p := range paths {
+		pathMap[p] = comp
+	}
+	return pathMap, nil
 }

--- a/pkg/options/gotmpl/go_template_applier_test.go
+++ b/pkg/options/gotmpl/go_template_applier_test.go
@@ -329,7 +329,7 @@ spec:
 				t.Fatalf("no objects found in new component")
 			}
 
-			strval, err := (&converter.ObjectExporter{Objects: newComp.Spec.Objects}).ExportAsYAML()
+			strval, err := converter.NewExporter(newComp).ObjectsAsSingleYAML()
 			if err != nil {
 				t.Fatalf("Error converting objects to yaml: %v", err)
 			}

--- a/pkg/wrapper/BUILD.bazel
+++ b/pkg/wrapper/BUILD.bazel
@@ -8,7 +8,6 @@ go_library(
     deps = [
         "//pkg/apis/bundle/v1alpha1:go_default_library",
         "//pkg/converter:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",
     ],
 )
 

--- a/pkg/wrapper/bundlewrapper.go
+++ b/pkg/wrapper/bundlewrapper.go
@@ -21,7 +21,6 @@ import (
 
 	bundle "github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/apis/bundle/v1alpha1"
 	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/converter"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 // BundleWrapper represents one of several possible bundle types -- a union type.
@@ -148,39 +147,4 @@ func (bw *BundleWrapper) AllComponents() []*bundle.Component {
 		return []*bundle.Component{bw.component}
 	}
 	return nil
-}
-
-// ExportAsObjects will export a Bundle as a ComponentSet and Components,
-// or a Component as unstructured Objects.
-func (bw *BundleWrapper) ExportAsObjects() ([]*unstructured.Unstructured, error) {
-	switch bw.Kind() {
-	case "Component":
-		return bw.Component().Spec.Objects, nil
-	case "Bundle":
-		bun := bw.Bundle()
-		y, err := converter.FromObject(bun.ComponentSet()).ToYAML()
-		if err != nil {
-			return nil, err
-		}
-		o, err := converter.FromYAML(y).ToUnstructured()
-		if err != nil {
-			return nil, err
-		}
-		var objs []*unstructured.Unstructured
-		objs = append(objs, o)
-		for _, c := range bun.Components {
-			y, err := converter.FromObject(c).ToYAML()
-			if err != nil {
-				return nil, err
-			}
-			o, err := converter.FromYAML(y).ToUnstructured()
-			if err != nil {
-				return nil, err
-			}
-			objs = append(objs, o)
-		}
-		return objs, nil
-	default:
-		return nil, fmt.Errorf("bundle kind %q not supported for exporting", bw.Kind())
-	}
 }


### PR DESCRIPTION
This PR adds BuildTags to the ComponentBuilder and uses them for
component exporting.

How it works:

- New repeated BuildTags field on the component-bulder object.
- This creates a new annotation when inlined.
- I reworked object / component exporting so that
  - `bundlectl export objects` just exports objects
  - `bundlectl export components` just exports components
  - `bundlectl export components --write-to=generated` will dump the
  components and the component sets into this directory. It's a
  configurable setting, but a bit fiddly.

The generated directory has the following formats (again, configurable)

`<write-to-dir>/<component-name>/<component-version>/<component-name>-<component-version>.yaml`
`<write-to-dir>/<component-name>/<build-tag>/<component-name>.yaml`
`<write-to-dir>/sets/<set-name>-<set-version>.yaml`

Example:

If 'foo' component @ version 1.0.3 has tag 'latest', then the following are generated:

```
generated/foo/1.0.3/foo-1.0.3.yaml
generated/foo/latest/foo.yaml
```

I've been fidling around with the format. Would love suggestions here.

Fixes: #155