### PR TITLE
Make inline not able to be set.

### DIFF
--- a/pkg/commands/build/build.go
+++ b/pkg/commands/build/build.go
@@ -22,8 +22,8 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/commands/cmdlib"
 	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/files"
 	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/filter"
-	log "k8s.io/klog"
 	"github.com/spf13/cobra"
+	log "k8s.io/klog"
 )
 
 // options represents options flags for the build command.

--- a/pkg/commands/root.go
+++ b/pkg/commands/root.go
@@ -62,9 +62,6 @@ func AddCommandsInternal(ctx context.Context, fio files.FileReaderWriter, sio cm
 		&cmdlib.GlobalOptionsValues.OutputFormat, "format", "", "", "The output file format. One of either 'json' or 'yaml'. "+
 			"If not specified, it defaults to yaml.")
 
-	rootCmd.PersistentFlags().BoolVarP(
-		&cmdlib.GlobalOptionsValues.Inline, "inline", "l", true, "Whether to inline files before processing")
-
 	build.AddCommandsTo(ctx, fio, sio, rootCmd)
 	export.AddCommandsTo(ctx, fio, sio, rootCmd)
 	filter.AddCommandsTo(ctx, fio, sio, rootCmd)


### PR DESCRIPTION
Inline doesn't make sense as a flag any longer, since you can only
inline during the build phase.

Work on #173

However, more work should be done to actually clean up this code.