### PR TITLE
Add an ObjectTemplateBuilder type.

### DIFF
--- a/pkg/apis/bundle/v1alpha1/object_template_types.go
+++ b/pkg/apis/bundle/v1alpha1/object_template_types.go
@@ -31,11 +31,6 @@ const (
 	GoTemplate TemplateType = "go-template"
 )
 
-const (
-	// TemplateTypeIdentifier is an annotation
-	TemplateTypeIdentifier Identifier = "bundle.gke.io/template-type"
-)
-
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ObjectTemplateBuilder contains configuration for creating ObjectTemplates.
@@ -47,8 +42,7 @@ type ObjectTemplateBuilder struct {
 	TemplateFile File `json:"templateFile,omitempty"`
 
 	// TemplateType indicates how the template should be detemplatized. By
-	// default, it assumes Go-Templates. During Build, this value is stored
-	// in the "bundle.gke.io/template-type" annotation.
+	// default, it assumes Go-Templates.
 	TemplateType TemplateType `json:"templateType,omitempty"`
 
 	// OptionsSchema is the schema for the parameters meant to be applied to

--- a/pkg/apis/bundle/v1alpha1/object_template_types.go
+++ b/pkg/apis/bundle/v1alpha1/object_template_types.go
@@ -23,8 +23,7 @@ import (
 type TemplateType string
 
 const (
-	// UndefinedTemplateType represents an undefined template type, and should
-	// default to GoTemplate.
+	// UndefinedTemplateType represents an undefined template type.
 	UndefinedTemplateType TemplateType = ""
 
 	// GoTemplate represents a go-template type.
@@ -42,7 +41,7 @@ type ObjectTemplateBuilder struct {
 	TemplateFile File `json:"templateFile,omitempty"`
 
 	// TemplateType indicates how the template should be detemplatized. By
-	// default, it assumes Go-Templates.
+	// default, it defaults to Go-Templates during build if left unspecified.
 	TemplateType TemplateType `json:"templateType,omitempty"`
 
 	// OptionsSchema is the schema for the parameters meant to be applied to
@@ -60,8 +59,8 @@ type ObjectTemplate struct {
 	// Template is a template-string that creates a K8S object.
 	Template string `json:"template,omitempty"`
 
-	// TemplateType indicates how the template should be detemplatized. By
-	// default, it assumes on Go-Templates.
+	// TemplateType is requried and indicates how the template should be
+	// detemplatized.
 	TemplateType TemplateType `json:"templateType,omitempty"`
 
 	// OptionsSchema is the schema for the parameters meant to be applied to

--- a/pkg/apis/bundle/v1alpha1/object_template_types.go
+++ b/pkg/apis/bundle/v1alpha1/object_template_types.go
@@ -28,8 +28,33 @@ const (
 	UndefinedTemplateType TemplateType = ""
 
 	// GoTemplate represents a go-template type.
-	GoTemplate TemplateType = "GoTemplate"
+	GoTemplate TemplateType = "go-template"
 )
+
+const (
+	// TemplateTypeIdentifier is an annotation
+	TemplateTypeIdentifier Identifier = "bundle.gke.io/template-type"
+)
+
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
+// ObjectTemplateBuilder contains configuration for creating ObjectTemplates.
+type ObjectTemplateBuilder struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	// TemplateFile is references a template file
+	TemplateFile File `json:"templateFile,omitempty"`
+
+	// TemplateType indicates how the template should be detemplatized. By
+	// default, it relies on Go-Templates. During Build, this value is stored
+	// in the "bundle.gke.io/template-type" annotation.
+	TemplateType TemplateType `json:"templateType,omitempty"`
+
+	// OptionsSchema is the schema for the parameters meant to be applied to
+	// the object template, which includes both defaulting and validation.
+	OptionsSchema *apiextensions.JSONSchemaProps `json:"optionsSchema,omitempty"`
+}
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
@@ -40,10 +65,6 @@ type ObjectTemplate struct {
 
 	// Template is a template that creates a K8S object.
 	Template string `json:"template,omitempty"`
-
-	// TemplateType indicates how the template should be detemplatized. By
-	// default, it relies on Go-Templates.
-	TemplateType TemplateType `json:"templateType,omitempty"`
 
 	// OptionsSchema is the schema for the parameters meant to be applied to
 	// the object template, which includes both defaulting and validation.

--- a/pkg/apis/bundle/v1alpha1/object_template_types.go
+++ b/pkg/apis/bundle/v1alpha1/object_template_types.go
@@ -47,7 +47,7 @@ type ObjectTemplateBuilder struct {
 	TemplateFile File `json:"templateFile,omitempty"`
 
 	// TemplateType indicates how the template should be detemplatized. By
-	// default, it relies on Go-Templates. During Build, this value is stored
+	// default, it assumes Go-Templates. During Build, this value is stored
 	// in the "bundle.gke.io/template-type" annotation.
 	TemplateType TemplateType `json:"templateType,omitempty"`
 
@@ -63,8 +63,12 @@ type ObjectTemplate struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	// Template is a template that creates a K8S object.
+	// Template is a template-string that creates a K8S object.
 	Template string `json:"template,omitempty"`
+
+	// TemplateType indicates how the template should be detemplatized. By
+	// default, it assumes on Go-Templates.
+	TemplateType TemplateType `json:"templateType,omitempty"`
 
 	// OptionsSchema is the schema for the parameters meant to be applied to
 	// the object template, which includes both defaulting and validation.

--- a/pkg/build/inline.go
+++ b/pkg/build/inline.go
@@ -122,83 +122,21 @@ var nonDNS = regexp.MustCompile(`[^-a-z0-9\.]`)
 // ComponentFiles reads file-references for component builder objects.
 // The returned components are copies with the file-references removed.
 func (n *Inliner) ComponentFiles(ctx context.Context, comp *bundle.ComponentBuilder) (*bundle.Component, error) {
-	name := comp.ComponentName
-	var newObjs []*unstructured.Unstructured
-	for _, cf := range comp.ObjectFiles {
-		contents, err := n.readFile(ctx, cf)
-		if err != nil {
-			return nil, fmt.Errorf("error reading file %v for component %q: %v", cf, name, err)
-		}
-		ext := filepath.Ext(cf.URL)
-		if ext == ".yaml" && multiDoc.Match(contents) {
-			splat := multiDoc.Split(string(contents), -1)
-			for i, s := range splat {
-				if onlyWhitespace.MatchString(s) {
-					continue
-				}
-				obj, err := converter.FromYAMLString(s).ToUnstructured()
-				if err != nil {
-					return nil, fmt.Errorf("converting multi-doc object number %d for component %q, %v", i, name, err)
-				}
-				annot := obj.GetAnnotations()
-				if annot == nil {
-					annot = make(map[string]string)
-				}
-				annot[string(bundle.InlineTypeIdentifier)] = string(bundle.KubeObjectInline)
-				obj.SetAnnotations(annot)
-				newObjs = append(newObjs, obj)
-			}
-		} else {
-			obj, err := converter.FromFileName(cf.URL, contents).ToUnstructured()
-			if err != nil {
-				return nil, fmt.Errorf("for component %q, %v", name, err)
-			}
-			annot := obj.GetAnnotations()
-			if annot == nil {
-				annot = make(map[string]string)
-			}
-			annot[string(bundle.InlineTypeIdentifier)] = string(bundle.KubeObjectInline)
-			obj.SetAnnotations(annot)
-			newObjs = append(newObjs, obj)
-		}
+	newObjs, err := n.objectFiles(ctx, comp.ObjectFiles, comp.ComponentReference())
+	if err != nil {
+		return nil, err
 	}
 
-	for _, fg := range comp.RawTextFiles {
-		fgName := fg.Name
-		if fgName == "" {
-			return nil, fmt.Errorf("error reading raw text file group object for component %q; name was empty ", name)
-		}
-		m := newConfigMapMaker(fgName)
-		for _, cf := range fg.Files {
-			text, err := n.readFile(ctx, cf)
-			if err != nil {
-				return nil, fmt.Errorf("error reading raw text file for component %q: %v", name, err)
-			}
-			dataName := filepath.Base(cf.URL)
-			if fg.AsBinary {
-				m.addBinaryData(dataName, text)
-			} else {
-				m.addData(dataName, string(text))
-			}
-		}
-		if len(m.cfgMap.Data) > 0 && len(m.cfgMap.BinaryData) > 0 {
-			return nil, fmt.Errorf("both and binary data were filled out for group: %v", fg)
-		}
-
-		m.cfgMap.ObjectMeta.Annotations[string(bundle.InlineTypeIdentifier)] = string(bundle.RawStringInline)
-		for key, value := range fg.Annotations {
-			m.cfgMap.ObjectMeta.Annotations[key] = value
-		}
-		for key, value := range fg.Labels {
-			m.cfgMap.ObjectMeta.Labels[key] = value
-		}
-
-		uns, err := m.toUnstructured()
-		if err != nil {
-			return nil, fmt.Errorf("for component %q and file group %q, %v", name, fgName, err)
-		}
-		newObjs = append(newObjs, uns)
+	newObjs, err = n.objectTemplateBuilders(ctx, newObjs, comp.ComponentReference())
+	if err != nil {
+		return nil, err
 	}
+
+	cfgObj, err := n.rawTextFiles(ctx, comp.RawTextFiles, comp.ComponentReference())
+	if err != nil {
+		return nil, err
+	}
+	newObjs = append(newObjs, cfgObj...)
 
 	om := *comp.ObjectMeta.DeepCopy()
 	if om.Name == "" {
@@ -237,6 +175,140 @@ func (n *Inliner) AllComponentFiles(ctx context.Context, cbs []*bundle.Component
 		out = append(out, newc)
 	}
 	return out, nil
+}
+
+// objectFiles inlines object files
+func (n *Inliner) objectFiles(ctx context.Context, objFiles []bundle.File, ref bundle.ComponentReference) ([]*unstructured.Unstructured, error) {
+	var newObjs []*unstructured.Unstructured
+	for _, cf := range objFiles {
+		contents, err := n.readFile(ctx, cf)
+		if err != nil {
+			return nil, fmt.Errorf("error reading file %v for component %v: %v", cf, ref, err)
+		}
+		ext := filepath.Ext(cf.URL)
+		if ext == ".yaml" && multiDoc.Match(contents) {
+			splat := multiDoc.Split(string(contents), -1)
+			for i, s := range splat {
+				if onlyWhitespace.MatchString(s) {
+					continue
+				}
+				obj, err := converter.FromYAMLString(s).ToUnstructured()
+				if err != nil {
+					return nil, fmt.Errorf("converting multi-doc object number %d for component %v, %v", i, ref, err)
+				}
+				annot := obj.GetAnnotations()
+				if annot == nil {
+					annot = make(map[string]string)
+				}
+				obj.SetAnnotations(annot)
+				newObjs = append(newObjs, obj)
+			}
+		} else {
+			obj, err := converter.FromFileName(cf.URL, contents).ToUnstructured()
+			if err != nil {
+				return nil, fmt.Errorf("for component %q, %v", ref, err)
+			}
+			annot := obj.GetAnnotations()
+			if annot == nil {
+				annot = make(map[string]string)
+			}
+			obj.SetAnnotations(annot)
+			newObjs = append(newObjs, obj)
+		}
+	}
+	return newObjs, nil
+}
+
+// objectTemplateBuilders builds ObjectTemplates from ObjectTemplateBuilders
+func (n *Inliner) objectTemplateBuilders(ctx context.Context, objects []*unstructured.Unstructured, ref bundle.ComponentReference) ([]*unstructured.Unstructured, error) {
+	var outObj []*unstructured.Unstructured
+	for _, obj := range objects {
+		if obj.GetKind() != "ObjectTemplateBuilder" {
+			outObj = append(outObj, obj)
+			continue
+		}
+		name := obj.GetName()
+
+		builder := &bundle.ObjectTemplateBuilder{}
+		if err := converter.FromUnstructured(obj).ToObject(builder); err != nil {
+			return nil, fmt.Errorf("for component %v and object %q: %v", ref, name, err)
+		}
+
+		contents, err := n.readFile(ctx, builder.TemplateFile)
+		if err != nil {
+			return nil, fmt.Errorf("for component %v and object %q: %v", ref, name, err)
+		}
+
+		objTemplate := &bundle.ObjectTemplate{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "bundle.gke.io/v1alpha1",
+				Kind:       "ObjectTemplate",
+			},
+			ObjectMeta:    builder.ObjectMeta,
+			OptionsSchema: builder.OptionsSchema,
+			Template:      string(contents),
+		}
+		if objTemplate.ObjectMeta.Annotations == nil {
+			objTemplate.ObjectMeta.Annotations = make(map[string]string)
+		}
+		tmplType := bundle.GoTemplate
+		if builder.TemplateType != bundle.UndefinedTemplateType {
+			tmplType = builder.TemplateType
+		}
+		objTemplate.ObjectMeta.Annotations[string(bundle.TemplateTypeIdentifier)] = string(tmplType)
+
+		objJSON, err := converter.FromObject(objTemplate).ToJSON()
+		if err != nil {
+			return nil, fmt.Errorf("for component %v and object %q, while converting back to JSON: %v", ref, name, err)
+		}
+
+		unsObj, err := converter.FromJSON(objJSON).ToUnstructured()
+		if err != nil {
+			return nil, fmt.Errorf("for component %v and object %q, while converting back to Unstructured: %v", ref, name, err)
+		}
+		outObj = append(outObj, unsObj)
+	}
+	return outObj, nil
+}
+
+func (n *Inliner) rawTextFiles(ctx context.Context, fileGroups []bundle.FileGroup, ref bundle.ComponentReference) ([]*unstructured.Unstructured, error) {
+	var newObjs []*unstructured.Unstructured
+	for _, fg := range fileGroups {
+		fgName := fg.Name
+		if fgName == "" {
+			return nil, fmt.Errorf("error reading raw text file group object for component %v; name was empty ", ref)
+		}
+		m := newConfigMapMaker(fgName)
+		for _, cf := range fg.Files {
+			text, err := n.readFile(ctx, cf)
+			if err != nil {
+				return nil, fmt.Errorf("error reading raw text file for component %q: %v", ref, err)
+			}
+			dataName := filepath.Base(cf.URL)
+			if fg.AsBinary {
+				m.addBinaryData(dataName, text)
+			} else {
+				m.addData(dataName, string(text))
+			}
+		}
+		if len(m.cfgMap.Data) > 0 && len(m.cfgMap.BinaryData) > 0 {
+			return nil, fmt.Errorf("both and binary data were filled out for group: %v", fg)
+		}
+
+		for key, value := range fg.Annotations {
+			m.cfgMap.ObjectMeta.Annotations[key] = value
+		}
+		for key, value := range fg.Labels {
+			m.cfgMap.ObjectMeta.Labels[key] = value
+		}
+
+		uns, err := m.toUnstructured()
+		if err != nil {
+			return nil, fmt.Errorf("for component %v and file group %q, %v", ref, fgName, err)
+		}
+		newObjs = append(newObjs, uns)
+	}
+	return newObjs, nil
 }
 
 // readFile from either a local or remote location.

--- a/pkg/build/inline.go
+++ b/pkg/build/inline.go
@@ -256,6 +256,7 @@ func (n *Inliner) objectTemplateBuilders(ctx context.Context, objects []*unstruc
 			tmplType = builder.TemplateType
 		}
 		objTemplate.ObjectMeta.Annotations[string(bundle.TemplateTypeIdentifier)] = string(tmplType)
+		objTemplate.TemplateType = tmplType
 
 		objJSON, err := converter.FromObject(objTemplate).ToJSON()
 		if err != nil {

--- a/pkg/build/inline.go
+++ b/pkg/build/inline.go
@@ -255,7 +255,6 @@ func (n *Inliner) objectTemplateBuilders(ctx context.Context, objects []*unstruc
 		if builder.TemplateType != bundle.UndefinedTemplateType {
 			tmplType = builder.TemplateType
 		}
-		objTemplate.ObjectMeta.Annotations[string(bundle.TemplateTypeIdentifier)] = string(tmplType)
 		objTemplate.TemplateType = tmplType
 
 		objJSON, err := converter.FromObject(objTemplate).ToJSON()

--- a/pkg/build/inline_test.go
+++ b/pkg/build/inline_test.go
@@ -478,6 +478,7 @@ metadata:
 						subStrings: []string{
 							"name: {{.foo}}",
 							"type: string",
+							"templateType: go-template",
 						},
 					},
 				},

--- a/pkg/build/inline_test.go
+++ b/pkg/build/inline_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/converter"
 	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/files"
 	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/testutil"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 type fakeLocalReader struct {
@@ -76,11 +75,8 @@ type bundleRef struct {
 }
 
 type objCheck struct {
-	name     string
-	annotKey string
-	annotVal string
-	labelKey string
-	labelVal string
+	name       string
+	subStrings []string
 
 	// For if it's imported as raw text
 	cfgMap map[string]string
@@ -120,11 +116,7 @@ func TestInlineBundleFiles(t *testing.T) {
 						Version:       "1.2.3",
 					},
 					obj: []objCheck{
-						{
-							name:     "biffbam",
-							annotKey: string(bundle.InlineTypeIdentifier),
-							annotVal: string(bundle.KubeObjectInline),
-						},
+						{name: "biffbam"},
 					},
 				},
 			},
@@ -148,11 +140,7 @@ componentFiles:
 						Version:       "1.2.3",
 					},
 					obj: []objCheck{
-						{
-							name:     "biffbam",
-							annotKey: string(bundle.InlineTypeIdentifier),
-							annotVal: string(bundle.KubeObjectInline),
-						},
+						{name: "biffbam"},
 					},
 				},
 			},
@@ -177,11 +165,7 @@ componentFiles:
 						Version:       "1.2.3",
 					},
 					obj: []objCheck{
-						{
-							name:     "biffbam",
-							annotKey: string(bundle.InlineTypeIdentifier),
-							annotVal: string(bundle.KubeObjectInline),
-						},
+						{name: "biffbam"},
 					},
 				},
 			},
@@ -218,12 +202,10 @@ rawTextFiles:
 					},
 					obj: []objCheck{
 						{
-							name:     "some-raw-text",
-							annotKey: string(bundle.InlineTypeIdentifier),
-							annotVal: string(bundle.RawStringInline),
-							cfgMap: map[string]string{
-								"raw-text.yaml":   "foobar",
-								"rawer-text.yaml": "boobar",
+							name: "some-raw-text",
+							subStrings: []string{
+								"foobar",
+								"boobar",
 							},
 						},
 					},
@@ -267,16 +249,8 @@ biff: bam`),
 						Version:       "2.3.4",
 					},
 					obj: []objCheck{
-						{
-							name:     "foobar",
-							annotKey: string(bundle.InlineTypeIdentifier),
-							annotVal: string(bundle.KubeObjectInline),
-						},
-						{
-							name:     "biffbam",
-							annotKey: string(bundle.InlineTypeIdentifier),
-							annotVal: string(bundle.KubeObjectInline),
-						},
+						{name: "foobar"},
+						{name: "biffbam"},
 					},
 				},
 			},
@@ -309,9 +283,7 @@ spec:
 						Version:       "2.3.4",
 					},
 					obj: []objCheck{
-						{
-							name: "foo-comp",
-						},
+						{name: "foo-comp"},
 					},
 				},
 			},
@@ -392,11 +364,7 @@ func TestInlineComponentFiles(t *testing.T) {
 					Version:       "1.2.3",
 				},
 				obj: []objCheck{
-					{
-						name:     "biffbam",
-						annotKey: string(bundle.InlineTypeIdentifier),
-						annotVal: string(bundle.KubeObjectInline),
-					},
+					{name: "biffbam"},
 				},
 			},
 		},
@@ -424,22 +392,19 @@ rawTextFiles:
 					Version:       "1.2.3",
 				},
 				obj: []objCheck{
+					{name: "data-blob"},
 					{
-						name:     "data-blob",
-						annotKey: string(bundle.InlineTypeIdentifier),
-						annotVal: string(bundle.RawStringInline),
+						name: "data-blob",
+						subStrings: []string{
+							"foo: bar",
+							"zip: zap",
+						},
 					},
 					{
-						name:     "data-blob",
-						annotKey: "foo",
-						annotVal: "bar",
-						labelKey: "zip",
-						labelVal: "zap",
-					},
-					{
-						name:     "data-blob",
-						annotKey: "biff",
-						annotVal: "bam",
+						name: "data-blob",
+						subStrings: []string{
+							"biff: bam",
+						},
 					},
 				},
 			},
@@ -466,11 +431,53 @@ rawTextFiles:
 				},
 				obj: []objCheck{
 					{
-						name:     "data-blob",
-						annotKey: string(bundle.InlineTypeIdentifier),
-						annotVal: string(bundle.RawStringInline),
-						binaryCfgMap: map[string]string{
-							"blobby.yaml": base64.StdEncoding.EncodeToString([]byte("blar")),
+						name: "data-blob",
+						subStrings: []string{
+							base64.StdEncoding.EncodeToString([]byte("blar")),
+						},
+					},
+				},
+			},
+		},
+
+		{
+			desc: "success: component, object template builder",
+			data: `
+kind: ComponentBuilder
+componentName: binary-blob
+version: 1.2.3
+objectFiles:
+- url: '/path/to/tmpl-builder.yaml'`,
+			files: map[string][]byte{
+				"/path/to/tmpl-builder.yaml": []byte(`
+kind: ObjectTemplateBuilder
+metadata:
+  name: obj-tmpl
+templateFile:
+  url: '/path/to/tmpl.yaml'
+optionsSchema:
+  properties:
+    foo:
+      type: string
+`),
+				"/path/to/tmpl.yaml": []byte(`
+kind: pod
+metadata:
+  name: {{.foo}}
+`),
+			},
+			expComp: compRef{
+				name: "binary-blob-1.2.3",
+				ref: bundle.ComponentReference{
+					ComponentName: "binary-blob",
+					Version:       "1.2.3",
+				},
+				obj: []objCheck{
+					{
+						name: "obj-tmpl",
+						subStrings: []string{
+							"name: {{.foo}}",
+							"type: string",
 						},
 					},
 				},
@@ -624,47 +631,23 @@ func validateComponents(t *testing.T, comp []*bundle.Component, expComps []compR
 		}
 
 		// Compare the object data
-		gotObjs := make(map[string]*unstructured.Unstructured)
+		gotObjYAML := make(map[string]string)
 		for _, obj := range comp.Spec.Objects {
-			gotObjs[obj.GetName()] = obj
+			objYAML, err := converter.FromObject(obj).ToYAMLString()
+			if err != nil {
+				t.Fatalf("converting object %q to yaml: %v", obj.GetName(), err)
+			}
+			gotObjYAML[obj.GetName()] = objYAML
 		}
-		for _, o := range ec.obj {
-			obj := gotObjs[o.name]
-			if obj == nil {
-				t.Errorf("got objs %v, but object with name name %q.", gotObjs, o.name)
-			}
-			an := obj.GetAnnotations()
-			if an[o.annotKey] != o.annotVal {
-				t.Errorf("for obj %q, got annotation val %q for key %q, but expected %q", o.name, an[o.annotKey], o.annotKey, o.annotVal)
-			}
-			lab := obj.GetLabels()
-			if lab[o.labelKey] != o.labelVal {
-				t.Errorf("for obj %q, got annotation val %q for key %q, but expected %q", o.name, lab[o.labelKey], o.labelKey, o.labelVal)
-			}
 
-			// Check the config map contents.
-			for expkey, expval := range o.cfgMap {
-				dataObj := obj.Object["data"]
-				dataMap, ok := dataObj.(map[string]interface{})
-				if !ok {
-					t.Fatalf("Expected data to be a map of string to interface for comp %v in object %q", ref, obj.GetName())
-				}
-				val, ok := dataMap[expkey].(string)
-				if !ok || val != expval {
-					t.Fatalf("Got value %q for key %q, but expected text object with value %q for comp %v in object %q. Map was %+v", val, expkey, expval, ref, obj.GetName(), dataMap)
-				}
+		for _, objCheck := range ec.obj {
+			obj := gotObjYAML[objCheck.name]
+			if obj == "" {
+				t.Errorf("got objs %v, but expected object with name name %q.", gotObjYAML, objCheck.name)
 			}
-
-			// Check the binary config map contents.
-			for expkey, expval := range o.binaryCfgMap {
-				dataObj := obj.Object["binaryData"]
-				dataMap, ok := dataObj.(map[string]interface{})
-				if !ok {
-					t.Fatalf("Expected data to be a map of string to interface for comp %v in object %q", ref, obj.GetName())
-				}
-				val, ok := dataMap[expkey].(string)
-				if !ok || string(val) != string(expval) {
-					t.Fatalf("Got value %q for key %q, but expected text with value %q for comp %v in object %q. Map was %+v", val, expkey, expval, ref, obj.GetName(), dataMap)
+			for _, expSubstring := range objCheck.subStrings {
+				if !strings.Contains(obj, expSubstring) {
+					t.Errorf("got obj %s, but expected it to contain %s", obj, expSubstring)
 				}
 			}
 		}


### PR DESCRIPTION
This PR adds a builder type for ObjectTemplates + inlining logic.

Additionally, this:

- Stops adding the inline annotation (TODO(self): remove completely)
- Refactors inlining to be clearer (with helper methods)
- Refactors the inlining test to check for substrs (good enough, clearer).

Partial work on #201 