### PR TITLE
Add relative-path support back.

### DIFF
--- a/examples/cluster/etcd/etcd-component.yaml
+++ b/examples/cluster/etcd/etcd-component.yaml
@@ -17,4 +17,4 @@ kind: ComponentBuilder
 componentName: etcd-component
 version: 30.0.2
 objectFiles:
-- url: file:///etcd/etcd-server.yaml
+- url: ./etcd-server.yaml

--- a/pkg/build/BUILD.bazel
+++ b/pkg/build/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
         "doc.go",
         "inline.go",
         "patchbuild.go",
+        "path_rewriter.go",
     ],
     importpath = "github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/build",
     visibility = ["//visibility:public"],

--- a/pkg/build/inline.go
+++ b/pkg/build/inline.go
@@ -76,7 +76,7 @@ func (n *Inliner) BundleFiles(ctx context.Context, data *bundle.BundleBuilder, b
 		if err != nil {
 			return nil, err
 		}
-		f.URL = n.PathRewriter.RewriteURL(bundleURL, furl).String()
+		f.URL = n.PathRewriter.MakeAbs(bundleURL, furl).String()
 
 		contents, err := n.readFile(ctx, f)
 		if err != nil {
@@ -206,7 +206,7 @@ func (n *Inliner) objectFiles(ctx context.Context, objFiles []bundle.File, ref b
 		if err != nil {
 			return nil, nil, err
 		}
-		cf.URL = n.PathRewriter.RewriteURL(componentPath, furl).String()
+		cf.URL = n.PathRewriter.MakeAbs(componentPath, furl).String()
 
 		contents, err := n.readFile(ctx, cf)
 		if err != nil {
@@ -274,7 +274,7 @@ func (n *Inliner) objectTemplateBuilders(ctx context.Context, objects map[string
 				return nil, err
 			}
 
-			builder.TemplateFile.URL = n.PathRewriter.RewriteURL(parentURL, furl).String()
+			builder.TemplateFile.URL = n.PathRewriter.MakeAbs(parentURL, furl).String()
 
 			contents, err := n.readFile(ctx, builder.TemplateFile)
 			if err != nil {
@@ -327,7 +327,7 @@ func (n *Inliner) rawTextFiles(ctx context.Context, fileGroups []bundle.FileGrou
 			if err != nil {
 				return nil, err
 			}
-			cf.URL = n.PathRewriter.RewriteURL(componentPath, furl).String()
+			cf.URL = n.PathRewriter.MakeAbs(componentPath, furl).String()
 
 			text, err := n.readFile(ctx, cf)
 			if err != nil {

--- a/pkg/build/inline.go
+++ b/pkg/build/inline.go
@@ -17,6 +17,7 @@ package build
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -34,6 +35,8 @@ import (
 type Inliner struct {
 	// Readers reads from the local filesystem.
 	Readers map[files.URLScheme]files.FileObjReader
+
+	PathRewriter *RelativePathRewriter
 }
 
 // NewLocalInliner creates a new inliner that only knows how to read local
@@ -56,15 +59,25 @@ func NewInlinerWithScheme(scheme files.URLScheme, objReader files.FileObjReader)
 		scheme: objReader,
 	}
 	return &Inliner{
-		Readers: rdrMap,
+		Readers:      rdrMap,
+		PathRewriter: DefaultPathRewriter,
 	}
 }
 
 // BundleFiles converts dereferences file-references in for bundle files.
-func (n *Inliner) BundleFiles(ctx context.Context, data *bundle.BundleBuilder) (*bundle.Bundle, error) {
-	var compbs []*bundle.ComponentBuilder
+func (n *Inliner) BundleFiles(ctx context.Context, data *bundle.BundleBuilder, bundlePath string) (*bundle.Bundle, error) {
+	bundleURL, err := url.Parse(bundlePath)
+	if err != nil {
+		return nil, err
+	}
 	var comps []*bundle.Component
 	for _, f := range data.ComponentFiles {
+		furl, err := f.ParsedURL()
+		if err != nil {
+			return nil, err
+		}
+		f.URL = n.PathRewriter.RewriteURL(bundleURL, furl).String()
+
 		contents, err := n.readFile(ctx, f)
 		if err != nil {
 			return nil, fmt.Errorf("error reading file %q: %v", f.URL, err)
@@ -90,17 +103,15 @@ func (n *Inliner) BundleFiles(ctx context.Context, data *bundle.BundleBuilder) (
 			if c.GetName() == "" && data.ComponentNamePolicy == "SetAndComponent" {
 				c.ObjectMeta.Name = strings.Join([]string{data.SetName, data.Version, c.ComponentName, c.Version}, "-")
 			}
-			compbs = append(compbs, c)
+			comp, err := n.ComponentFiles(ctx, c, furl.String())
+			if err != nil {
+				return nil, err
+			}
+			comps = append(comps, comp)
 		default:
 			return nil, fmt.Errorf("unsupported kind for component: %q; only supported kinds are Component and ComponentBuilder", kind)
 		}
 	}
-
-	inlComps, err := n.AllComponentFiles(ctx, compbs)
-	if err != nil {
-		return nil, err
-	}
-	comps = append(comps, inlComps...)
 
 	newBundle := &bundle.Bundle{
 		TypeMeta: metav1.TypeMeta{
@@ -121,18 +132,24 @@ var nonDNS = regexp.MustCompile(`[^-a-z0-9\.]`)
 
 // ComponentFiles reads file-references for component builder objects.
 // The returned components are copies with the file-references removed.
-func (n *Inliner) ComponentFiles(ctx context.Context, comp *bundle.ComponentBuilder) (*bundle.Component, error) {
-	newObjs, err := n.objectFiles(ctx, comp.ObjectFiles, comp.ComponentReference())
+func (n *Inliner) ComponentFiles(ctx context.Context, comp *bundle.ComponentBuilder, componentPath string) (*bundle.Component, error) {
+	componentURL, err := url.Parse(componentPath)
 	if err != nil {
 		return nil, err
 	}
 
-	newObjs, err = n.objectTemplateBuilders(ctx, newObjs, comp.ComponentReference())
+	newObjs, tmplBuilders, err := n.objectFiles(ctx, comp.ObjectFiles, comp.ComponentReference(), componentURL)
 	if err != nil {
 		return nil, err
 	}
 
-	cfgObj, err := n.rawTextFiles(ctx, comp.RawTextFiles, comp.ComponentReference())
+	tmplObjs, err := n.objectTemplateBuilders(ctx, tmplBuilders, comp.ComponentReference())
+	if err != nil {
+		return nil, err
+	}
+	newObjs = append(newObjs, tmplObjs...)
+
+	cfgObj, err := n.rawTextFiles(ctx, comp.RawTextFiles, comp.ComponentReference(), componentURL)
 	if err != nil {
 		return nil, err
 	}
@@ -168,7 +185,7 @@ func (n *Inliner) ComponentFiles(ctx context.Context, comp *bundle.ComponentBuil
 func (n *Inliner) AllComponentFiles(ctx context.Context, cbs []*bundle.ComponentBuilder) ([]*bundle.Component, error) {
 	var out []*bundle.Component
 	for _, cb := range cbs {
-		newc, err := n.ComponentFiles(ctx, cb)
+		newc, err := n.ComponentFiles(ctx, cb, "")
 		if err != nil {
 			return nil, err
 		}
@@ -177,13 +194,23 @@ func (n *Inliner) AllComponentFiles(ctx context.Context, cbs []*bundle.Component
 	return out, nil
 }
 
-// objectFiles inlines object files
-func (n *Inliner) objectFiles(ctx context.Context, objFiles []bundle.File, ref bundle.ComponentReference) ([]*unstructured.Unstructured, error) {
+// objectFiles inlines object files. in the success case, it returns
+//
+// 1.) The inlined object files.
+// 2.) A map of path-to-ObjectTemplateBuilder
+func (n *Inliner) objectFiles(ctx context.Context, objFiles []bundle.File, ref bundle.ComponentReference, componentPath *url.URL) ([]*unstructured.Unstructured, map[string][]*unstructured.Unstructured, error) {
 	var newObjs []*unstructured.Unstructured
+	objTmplBuilders := make(map[string][]*unstructured.Unstructured)
 	for _, cf := range objFiles {
+		furl, err := cf.ParsedURL()
+		if err != nil {
+			return nil, nil, err
+		}
+		cf.URL = n.PathRewriter.RewriteURL(componentPath, furl).String()
+
 		contents, err := n.readFile(ctx, cf)
 		if err != nil {
-			return nil, fmt.Errorf("error reading file %v for component %v: %v", cf, ref, err)
+			return nil, nil, fmt.Errorf("error reading file %v for component %v: %v", cf, ref, err)
 		}
 		ext := filepath.Ext(cf.URL)
 		if ext == ".yaml" && multiDoc.Match(contents) {
@@ -194,84 +221,100 @@ func (n *Inliner) objectFiles(ctx context.Context, objFiles []bundle.File, ref b
 				}
 				obj, err := converter.FromYAMLString(s).ToUnstructured()
 				if err != nil {
-					return nil, fmt.Errorf("converting multi-doc object number %d for component %v, %v", i, ref, err)
+					return nil, nil, fmt.Errorf("converting multi-doc object number %d for component %v, %v", i, ref, err)
 				}
-				annot := obj.GetAnnotations()
-				if annot == nil {
-					annot = make(map[string]string)
+				if obj.GetKind() == "ObjectTemplateBuilder" {
+					if objTmplBuilders[cf.URL] == nil {
+						objTmplBuilders[cf.URL] = []*unstructured.Unstructured{obj}
+					} else {
+						objTmplBuilders[cf.URL] = append(objTmplBuilders[cf.URL], obj)
+					}
+				} else {
+					newObjs = append(newObjs, obj)
 				}
-				obj.SetAnnotations(annot)
-				newObjs = append(newObjs, obj)
 			}
 		} else {
 			obj, err := converter.FromFileName(cf.URL, contents).ToUnstructured()
 			if err != nil {
-				return nil, fmt.Errorf("for component %q, %v", ref, err)
+				return nil, nil, fmt.Errorf("for component %q, %v", ref, err)
 			}
-			annot := obj.GetAnnotations()
-			if annot == nil {
-				annot = make(map[string]string)
+			if obj.GetKind() == "ObjectTemplateBuilder" {
+				objTmplBuilders[cf.URL] = []*unstructured.Unstructured{obj}
+			} else {
+				newObjs = append(newObjs, obj)
 			}
-			obj.SetAnnotations(annot)
-			newObjs = append(newObjs, obj)
 		}
 	}
-	return newObjs, nil
+	return newObjs, objTmplBuilders, nil
 }
 
 // objectTemplateBuilders builds ObjectTemplates from ObjectTemplateBuilders
-func (n *Inliner) objectTemplateBuilders(ctx context.Context, objects []*unstructured.Unstructured, ref bundle.ComponentReference) ([]*unstructured.Unstructured, error) {
+func (n *Inliner) objectTemplateBuilders(ctx context.Context, objects map[string][]*unstructured.Unstructured, ref bundle.ComponentReference) ([]*unstructured.Unstructured, error) {
 	var outObj []*unstructured.Unstructured
-	for _, obj := range objects {
-		if obj.GetKind() != "ObjectTemplateBuilder" {
-			outObj = append(outObj, obj)
-			continue
-		}
-		name := obj.GetName()
+	for parentPath, objList := range objects {
+		for _, obj := range objList {
+			if obj.GetKind() != "ObjectTemplateBuilder" {
+				// There shouldn't be any ObjectTemplateBuilders at this point
+				continue
+			}
+			name := obj.GetName()
 
-		builder := &bundle.ObjectTemplateBuilder{}
-		if err := converter.FromUnstructured(obj).ToObject(builder); err != nil {
-			return nil, fmt.Errorf("for component %v and object %q: %v", ref, name, err)
-		}
+			builder := &bundle.ObjectTemplateBuilder{}
+			if err := converter.FromUnstructured(obj).ToObject(builder); err != nil {
+				return nil, fmt.Errorf("for component %v and object %q: %v", ref, name, err)
+			}
 
-		contents, err := n.readFile(ctx, builder.TemplateFile)
-		if err != nil {
-			return nil, fmt.Errorf("for component %v and object %q: %v", ref, name, err)
-		}
+			parentURL, err := url.Parse(parentPath)
+			if err != nil {
+				return nil, err
+			}
 
-		objTemplate := &bundle.ObjectTemplate{
-			TypeMeta: metav1.TypeMeta{
-				APIVersion: "bundle.gke.io/v1alpha1",
-				Kind:       "ObjectTemplate",
-			},
-			ObjectMeta:    builder.ObjectMeta,
-			OptionsSchema: builder.OptionsSchema,
-			Template:      string(contents),
-		}
-		if objTemplate.ObjectMeta.Annotations == nil {
-			objTemplate.ObjectMeta.Annotations = make(map[string]string)
-		}
-		tmplType := bundle.GoTemplate
-		if builder.TemplateType != bundle.UndefinedTemplateType {
-			tmplType = builder.TemplateType
-		}
-		objTemplate.TemplateType = tmplType
+			furl, err := builder.TemplateFile.ParsedURL()
+			if err != nil {
+				return nil, err
+			}
 
-		objJSON, err := converter.FromObject(objTemplate).ToJSON()
-		if err != nil {
-			return nil, fmt.Errorf("for component %v and object %q, while converting back to JSON: %v", ref, name, err)
-		}
+			builder.TemplateFile.URL = n.PathRewriter.RewriteURL(parentURL, furl).String()
 
-		unsObj, err := converter.FromJSON(objJSON).ToUnstructured()
-		if err != nil {
-			return nil, fmt.Errorf("for component %v and object %q, while converting back to Unstructured: %v", ref, name, err)
+			contents, err := n.readFile(ctx, builder.TemplateFile)
+			if err != nil {
+				return nil, fmt.Errorf("for component %v and object %q: %v", ref, name, err)
+			}
+
+			objTemplate := &bundle.ObjectTemplate{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "bundle.gke.io/v1alpha1",
+					Kind:       "ObjectTemplate",
+				},
+				ObjectMeta:    builder.ObjectMeta,
+				OptionsSchema: builder.OptionsSchema,
+				Template:      string(contents),
+			}
+			if objTemplate.ObjectMeta.Annotations == nil {
+				objTemplate.ObjectMeta.Annotations = make(map[string]string)
+			}
+			tmplType := bundle.GoTemplate
+			if builder.TemplateType != bundle.UndefinedTemplateType {
+				tmplType = builder.TemplateType
+			}
+			objTemplate.TemplateType = tmplType
+
+			objJSON, err := converter.FromObject(objTemplate).ToJSON()
+			if err != nil {
+				return nil, fmt.Errorf("for component %v and object %q, while converting back to JSON: %v", ref, name, err)
+			}
+
+			unsObj, err := converter.FromJSON(objJSON).ToUnstructured()
+			if err != nil {
+				return nil, fmt.Errorf("for component %v and object %q, while converting back to Unstructured: %v", ref, name, err)
+			}
+			outObj = append(outObj, unsObj)
 		}
-		outObj = append(outObj, unsObj)
 	}
 	return outObj, nil
 }
 
-func (n *Inliner) rawTextFiles(ctx context.Context, fileGroups []bundle.FileGroup, ref bundle.ComponentReference) ([]*unstructured.Unstructured, error) {
+func (n *Inliner) rawTextFiles(ctx context.Context, fileGroups []bundle.FileGroup, ref bundle.ComponentReference, componentPath *url.URL) ([]*unstructured.Unstructured, error) {
 	var newObjs []*unstructured.Unstructured
 	for _, fg := range fileGroups {
 		fgName := fg.Name
@@ -280,6 +323,12 @@ func (n *Inliner) rawTextFiles(ctx context.Context, fileGroups []bundle.FileGrou
 		}
 		m := newConfigMapMaker(fgName)
 		for _, cf := range fg.Files {
+			furl, err := cf.ParsedURL()
+			if err != nil {
+				return nil, err
+			}
+			cf.URL = n.PathRewriter.RewriteURL(componentPath, furl).String()
+
 			text, err := n.readFile(ctx, cf)
 			if err != nil {
 				return nil, fmt.Errorf("error reading raw text file for component %q: %v", ref, err)

--- a/pkg/build/inline_integration_test.go
+++ b/pkg/build/inline_integration_test.go
@@ -25,7 +25,8 @@ import (
 
 func TestRealisticDataParseAndInline_Bundle(t *testing.T) {
 	ctx := context.Background()
-	b, err := ioutil.ReadFile("../../examples/cluster/bundle-builder-example.yaml")
+	bundlePath := "../../examples/cluster/bundle-builder-example.yaml"
+	b, err := ioutil.ReadFile(bundlePath)
 	if err != nil {
 		t.Fatalf("Error reading file %v", err)
 	}
@@ -41,7 +42,7 @@ func TestRealisticDataParseAndInline_Bundle(t *testing.T) {
 
 	inliner := NewLocalInliner("../../examples/cluster/")
 
-	moreInlined, err := inliner.BundleFiles(ctx, dataFiles)
+	moreInlined, err := inliner.BundleFiles(ctx, dataFiles, bundlePath)
 	if err != nil {
 		t.Fatalf("Error calling BundleFiles(): %v", err)
 	}
@@ -61,7 +62,8 @@ func TestRealisticDataParseAndInline_Bundle(t *testing.T) {
 
 func TestRealisticDataParseAndInline_Component(t *testing.T) {
 	ctx := context.Background()
-	b, err := ioutil.ReadFile("../../examples/component/etcd-component-builder.yaml")
+	dataPath := "../../examples/component/etcd-component-builder.yaml"
+	b, err := ioutil.ReadFile(dataPath)
 	if err != nil {
 		t.Fatalf("Error reading file %v", err)
 	}
@@ -77,7 +79,7 @@ func TestRealisticDataParseAndInline_Component(t *testing.T) {
 
 	inliner := NewLocalInliner("../../examples/component/")
 
-	component, err := inliner.ComponentFiles(ctx, cb)
+	component, err := inliner.ComponentFiles(ctx, cb, dataPath)
 	if err != nil {
 		t.Fatalf("Error calling ComponentFiles(): %v", err)
 	}

--- a/pkg/build/path_rewriter.go
+++ b/pkg/build/path_rewriter.go
@@ -22,18 +22,21 @@ import (
 // RelativePathRewriter rewrites paths when the paths are relative paths.
 type RelativePathRewriter struct{}
 
-// RewritePath rewrites file paths if the path is relative, from the
+// MakeAbs rewrites file paths if the path is relative, from the
 // original object path, to an object path that's based on a parent component
-// path.
+// path. Note that the parent path must be an absolute path.
 //
 // For example, if the component path is foo/bar/biff.yaml and the object path
 // is zed/fred.yaml, the object will be rewritten as foo/bar/zed/fred.yaml
-func (rw *RelativePathRewriter) RewriteURL(parent, obj *url.URL) *url.URL {
+func (rw *RelativePathRewriter) MakeAbs(parent, obj *url.URL) *url.URL {
 	if parent == nil || obj == nil {
 		return obj
 	}
 	if parent.Scheme != "file" && parent.Scheme != "" {
 		// Only file schemes are supported.
+		return obj
+	}
+	if !filepath.IsAbs(parent.Path) {
 		return obj
 	}
 	if filepath.IsAbs(obj.Path) {
@@ -42,7 +45,7 @@ func (rw *RelativePathRewriter) RewriteURL(parent, obj *url.URL) *url.URL {
 	return &url.URL{
 		Scheme: parent.Scheme,
 		Host:   parent.Host,
-		Path:   filepath.Join(filepath.Dir(parent.Path), obj.Path),
+		Path:   filepath.Clean(filepath.Join(filepath.Dir(parent.Path), obj.Path)),
 	}
 }
 

--- a/pkg/build/path_rewriter.go
+++ b/pkg/build/path_rewriter.go
@@ -1,0 +1,50 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build
+
+import (
+	"net/url"
+	"path/filepath"
+)
+
+// RelativePathRewriter rewrites paths when the paths are relative paths.
+type RelativePathRewriter struct{}
+
+// RewritePath rewrites file paths if the path is relative, from the
+// original object path, to an object path that's based on a parent component
+// path.
+//
+// For example, if the component path is foo/bar/biff.yaml and the object path
+// is zed/fred.yaml, the object will be rewritten as foo/bar/zed/fred.yaml
+func (rw *RelativePathRewriter) RewriteURL(parent, obj *url.URL) *url.URL {
+	if parent == nil || obj == nil {
+		return obj
+	}
+	if parent.Scheme != "file" && parent.Scheme != "" {
+		// Only file schemes are supported.
+		return obj
+	}
+	if filepath.IsAbs(obj.Path) {
+		return obj
+	}
+	return &url.URL{
+		Scheme: parent.Scheme,
+		Host:   parent.Host,
+		Path:   filepath.Join(filepath.Dir(parent.Path), obj.Path),
+	}
+}
+
+// DefaultPathRewriter provides a RelativePathRewriter instance.
+var DefaultPathRewriter = &RelativePathRewriter{}

--- a/pkg/commands/build/BUILD.bazel
+++ b/pkg/commands/build/BUILD.bazel
@@ -3,8 +3,8 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = [
-        "get_command.go",
         "build.go",
+        "get_command.go",
     ],
     importpath = "github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/commands/build",
     visibility = ["//visibility:public"],

--- a/pkg/commands/cmdlib/bundleio.go
+++ b/pkg/commands/cmdlib/bundleio.go
@@ -64,8 +64,8 @@ func (r *RealStdioReaderWriter) Write(b []byte) (int, error) {
 }
 
 type fileInliner interface {
-	BundleFiles(context.Context, *bundle.BundleBuilder) (*bundle.Bundle, error)
-	ComponentFiles(context.Context, *bundle.ComponentBuilder) (*bundle.Component, error)
+	BundleFiles(context.Context, *bundle.BundleBuilder, string) (*bundle.Bundle, error)
+	ComponentFiles(context.Context, *bundle.ComponentBuilder, string) (*bundle.Component, error)
 }
 
 // BundleReaderWriter provides a mockable reading / writing interface for
@@ -138,13 +138,13 @@ func (brw *realBundleReaderWriter) inlineData(ctx context.Context, bw *wrapper.B
 	inliner := brw.makeInlinerFn(brw.rw, g.InputFile)
 	switch bw.Kind() {
 	case "BundleBuilder":
-		newBun, err := inliner.BundleFiles(ctx, bw.BundleBuilder())
+		newBun, err := inliner.BundleFiles(ctx, bw.BundleBuilder(), g.InputFile)
 		if err != nil {
 			return nil, fmt.Errorf("error inlining component data files: %v", err)
 		}
 		return wrapper.FromBundle(newBun), nil
 	case "ComponentBuilder":
-		newComp, err := inliner.ComponentFiles(ctx, bw.ComponentBuilder())
+		newComp, err := inliner.ComponentFiles(ctx, bw.ComponentBuilder(), g.InputFile)
 		if err != nil {
 			return nil, fmt.Errorf("error inlining objects: %v", err)
 		}

--- a/pkg/commands/cmdlib/bundleio_test.go
+++ b/pkg/commands/cmdlib/bundleio_test.go
@@ -74,7 +74,7 @@ type fakeInliner struct {
 	err          error
 }
 
-func (f *fakeInliner) BundleFiles(_ context.Context, b *bundle.BundleBuilder) (*bundle.Bundle, error) {
+func (f *fakeInliner) BundleFiles(_ context.Context, b *bundle.BundleBuilder, _ string) (*bundle.Bundle, error) {
 	f.bundleIn = b
 	o, err := converter.FromYAMLString(f.bundleOut).ToBundle()
 	if err != nil {
@@ -83,7 +83,7 @@ func (f *fakeInliner) BundleFiles(_ context.Context, b *bundle.BundleBuilder) (*
 	return o, f.err
 }
 
-func (f *fakeInliner) ComponentFiles(_ context.Context, c *bundle.ComponentBuilder) (*bundle.Component, error) {
+func (f *fakeInliner) ComponentFiles(_ context.Context, c *bundle.ComponentBuilder, _ string) (*bundle.Component, error) {
 	f.componentIn = c
 	o, err := converter.FromYAMLString(f.componentOut).ToComponent()
 	if err != nil {

--- a/pkg/commands/export/BUILD.bazel
+++ b/pkg/commands/export/BUILD.bazel
@@ -3,8 +3,8 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = [
-        "get_command.go",
         "export.go",
+        "get_command.go",
     ],
     importpath = "github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/commands/export",
     visibility = ["//visibility:public"],

--- a/pkg/commands/filter/BUILD.bazel
+++ b/pkg/commands/filter/BUILD.bazel
@@ -3,8 +3,8 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = [
-        "get_command.go",
         "filter.go",
+        "get_command.go",
     ],
     importpath = "github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/commands/filter",
     visibility = ["//visibility:public"],

--- a/pkg/testutil/componentsuite/componentsuite.go
+++ b/pkg/testutil/componentsuite/componentsuite.go
@@ -72,7 +72,7 @@ func Run(t *testing.T, testSuiteFile string) {
 	var comp *bundle.Component
 	if bw.Kind() == "ComponentBuilder" {
 		inliner := build.NewLocalInliner(ts.RootDirectory)
-		comp, err = inliner.ComponentFiles(ctx, bw.ComponentBuilder())
+		comp, err = inliner.ComponentFiles(ctx, bw.ComponentBuilder(), ts.ComponentFile)
 		if err != nil {
 		}
 	} else {


### PR DESCRIPTION
This PR adds relative path support back. You can now specify relative
paths for any of the file URLs. File-paths will be rewritten only if the
child-file path (e.g., an object in a component) is a relative path.

Fixes: #227