### PR TITLE
Add a intgration test framework for bundlectl commands.

### DIFF
--- a/pkg/apis/bundle/v1alpha1/object_template_types.go
+++ b/pkg/apis/bundle/v1alpha1/object_template_types.go
@@ -26,7 +26,7 @@ const (
 	// TemplateTypeUndefined represents an undefined template type.
 	TemplateTypeUndefined TemplateType = ""
 
-	// TemplateGo represents a go-template, which is assumed to be YAML.
+	// TemplateTypeGo represents a go-template, which is assumed to be YAML.
 	TemplateTypeGo TemplateType = "go-template"
 )
 

--- a/pkg/commands/cmdlib/BUILD.bazel
+++ b/pkg/commands/cmdlib/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "bundleio.go",
+        "cmdio.go",
         "doc.go",
         "global_options.go",
     ],
@@ -26,8 +27,10 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/apis/bundle/v1alpha1:go_default_library",
+        "//pkg/commands/cmdtest:go_default_library",
         "//pkg/converter:go_default_library",
         "//pkg/files:go_default_library",
+        "//pkg/testutil:go_default_library",
         "//pkg/wrapper:go_default_library",
     ],
 )

--- a/pkg/commands/cmdlib/cmdio.go
+++ b/pkg/commands/cmdlib/cmdio.go
@@ -1,0 +1,54 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmdlib
+
+import (
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/files"
+	log "k8s.io/klog"
+)
+
+// CmdIO contains dependencies for doing I/O in commands.
+type CmdIO struct {
+	// StdIO preforms I/O to stdout.
+	StdIO StdioReaderWriter
+
+	// FileIO performs I/O to files
+	FileIO files.FileReaderWriter
+
+	// ExitIO exits the program with some message.
+	ExitIO Exiter
+}
+
+// Exiter is a thing that can exit with messages.
+type Exiter interface {
+	// Exit the program with args.
+	Exit(args ...interface{})
+
+	// Exit the program with a formatted message.
+	Exitf(format string, v ...interface{})
+}
+
+// RealExiter exits the program with some message.
+type RealExiter struct{}
+
+// Exit calls log.Exit.
+func (e *RealExiter) Exit(args ...interface{}) {
+	log.Exit(args...)
+}
+
+// Exitf calls log.Exitf.
+func (e *RealExiter) Exitf(format string, v ...interface{}) {
+	log.Exitf(format, v...)
+}

--- a/pkg/commands/cmdrunner/BUILD.bazel
+++ b/pkg/commands/cmdrunner/BUILD.bazel
@@ -1,0 +1,13 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["execute_cmd.go"],
+    importpath = "github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/commands/cmdrunner",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/commands:go_default_library",
+        "//pkg/commands/cmdlib:go_default_library",
+        "//pkg/commands/cmdtest:go_default_library",
+    ],
+)

--- a/pkg/commands/cmdrunner/execute_cmd.go
+++ b/pkg/commands/cmdrunner/execute_cmd.go
@@ -12,27 +12,30 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package version contains the version command.
-package version
+// Package cmdrunner is a utility for running integration tests for commands.
+package cmdrunner
 
 import (
+	"context"
+	"flag"
+
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/commands"
 	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/commands/cmdlib"
-	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/version"
-	"github.com/spf13/cobra"
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/commands/cmdtest"
 )
 
-// GetCommand returns the version command.
-func GetCommand(cio *cmdlib.CmdIO) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "version",
-		Short: "List version of bundlectl",
-		Long:  "List version of bundlectl",
-		Run: func(cmd *cobra.Command, _ []string) {
-			_, err := cio.StdIO.Write([]byte(version.BundlectlVersion))
-			if err != nil {
-				cio.ExitIO.Exit(err)
-			}
-		},
+// ExecuteCommand executes a fake command.
+func ExecuteCommand(fakeio *cmdtest.FakeCmdIO, args []string) error {
+	ctx := context.Background()
+
+	cmdio := &cmdlib.CmdIO{
+		StdIO:  fakeio.StdIO,
+		FileIO: fakeio.FileIO,
+		ExitIO: fakeio.ExitIO,
 	}
-	return cmd
+
+	flagset := flag.NewFlagSet("test-flagset", flag.ContinueOnError)
+
+	cmd := commands.AddCommandsInternal(ctx, cmdio, flagset, args)
+	return cmd.Execute()
 }

--- a/pkg/commands/cmdtest/BUILD.bazel
+++ b/pkg/commands/cmdtest/BUILD.bazel
@@ -1,0 +1,13 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "fake_cmd_io.go",
+        "fake_exiter.go",
+        "fake_stdio.go",
+    ],
+    importpath = "github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/commands/cmdtest",
+    visibility = ["//visibility:public"],
+    deps = ["//pkg/testutil:go_default_library"],
+)

--- a/pkg/commands/cmdtest/fake_cmd_io.go
+++ b/pkg/commands/cmdtest/fake_cmd_io.go
@@ -1,0 +1,36 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package cmdtest provides test utilities for testing commands.
+package cmdtest
+
+import (
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/testutil"
+)
+
+// FakeCmdIO contains fake implementations of the CmdIo dependencies
+type FakeCmdIO struct {
+	StdIO  *FakeStdioReaderWriter
+	FileIO *testutil.FakeFileReaderWriter
+	ExitIO *FakeExiter
+}
+
+// NewFakeCmdIO creates a new FakeCmdIO
+func NewFakeCmdIO() *FakeCmdIO {
+	return &FakeCmdIO{
+		StdIO:  &FakeStdioReaderWriter{},
+		FileIO: testutil.NewEmptyReaderWriter(),
+		ExitIO: &FakeExiter{},
+	}
+}

--- a/pkg/commands/cmdtest/fake_exiter.go
+++ b/pkg/commands/cmdtest/fake_exiter.go
@@ -1,0 +1,35 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmdtest
+
+import (
+	"fmt"
+)
+
+// FakeExiter doesn't exit, but instead stores the exit message
+type FakeExiter struct {
+	// Message is the exit message
+	Message string
+}
+
+// Exit stores the exit message
+func (e *FakeExiter) Exit(args ...interface{}) {
+	e.Message = fmt.Sprint(args...)
+}
+
+// Exitf stores the exit message
+func (e *FakeExiter) Exitf(format string, v ...interface{}) {
+	e.Message = fmt.Sprintf(format, v...)
+}

--- a/pkg/commands/cmdtest/fake_stdio.go
+++ b/pkg/commands/cmdtest/fake_stdio.go
@@ -1,0 +1,50 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmdtest
+
+// FakeStdioReaderWriter is a fake implementation of a reader/writer to
+// stdout.
+type FakeStdioReaderWriter struct {
+	// ReadBytes contains the bytes to be read.
+	ReadBytes []byte
+
+	// ReadErr is an error that occurs during Read. If ReadErr is present, then
+	// ReadErr will be returned instead of ReadBytes
+	ReadErr error
+
+	// WriteBytes contains a record of the most-recently written bytes.
+	WriteBytes []byte
+
+	// WriteErr is an error that occurs during Write. If WriteErr is present, then
+	// Write will write not write content and return WriteErr instead.
+	WriteErr error
+}
+
+// ReadAll returns all the ReadBytes or returns an error.
+func (f *FakeStdioReaderWriter) ReadAll() ([]byte, error) {
+	if f.ReadErr != nil {
+		return nil, f.ReadErr
+	}
+	return f.ReadBytes, nil
+}
+
+// Write stores all the WriteBytes or returns an error.
+func (f *FakeStdioReaderWriter) Write(b []byte) (int, error) {
+	if f.WriteErr != nil {
+		return 0, f.WriteErr
+	}
+	f.WriteBytes = b
+	return len(f.WriteBytes), nil
+}

--- a/pkg/commands/find/get_command.go
+++ b/pkg/commands/find/get_command.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package export contains commands for finding components and objects.
+// Package find contains commands for finding components and objects.
 package find
 
 import (

--- a/pkg/commands/patch/patch.go
+++ b/pkg/commands/patch/patch.go
@@ -18,8 +18,8 @@ import (
 	"context"
 	"fmt"
 
-	log "k8s.io/klog"
 	"github.com/spf13/cobra"
+	log "k8s.io/klog"
 
 	bundle "github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/apis/bundle/v1alpha1"
 	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/commands/cmdlib"

--- a/pkg/commands/version/BUILD.bazel
+++ b/pkg/commands/version/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -6,7 +6,18 @@ go_library(
     importpath = "github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/commands/version",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/commands/cmdlib:go_default_library",
         "//pkg/version:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["version_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//pkg/commands/cmdrunner:go_default_library",
+        "//pkg/commands/cmdtest:go_default_library",
     ],
 )

--- a/pkg/commands/version/version_test.go
+++ b/pkg/commands/version/version_test.go
@@ -1,0 +1,45 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package version_test
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/commands/cmdrunner"
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/commands/cmdtest"
+)
+
+var (
+	// TODO(kashomon): Use a real SemVer library to test this.
+	numPattern     = `([1-9]\d*|0)`
+	versionPattern = regexp.MustCompile(fmt.Sprintf(`^%s\.%s\.%s$`, numPattern, numPattern, numPattern))
+)
+
+func TestVersion(t *testing.T) {
+	fakeio := cmdtest.NewFakeCmdIO()
+
+	if err := cmdrunner.ExecuteCommand(fakeio, []string{
+		"version",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	version := string(fakeio.StdIO.WriteBytes)
+	if !versionPattern.MatchString(version) {
+		t.Errorf("Got version %s, but expected it to have the form X.Y.Z", version)
+	}
+}

--- a/pkg/testutil/BUILD.bazel
+++ b/pkg/testutil/BUILD.bazel
@@ -9,8 +9,5 @@ go_library(
     ],
     importpath = "github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/testutil",
     visibility = ["//visibility:public"],
-    deps = [
-        "//pkg/apis/bundle/v1alpha1:go_default_library",
-        "//pkg/files:go_default_library",
-    ],
+    deps = ["//pkg/apis/bundle/v1alpha1:go_default_library"],
 )

--- a/pkg/testutil/fake_reader_writer.go
+++ b/pkg/testutil/fake_reader_writer.go
@@ -20,39 +20,36 @@ import (
 	"os"
 
 	bundle "github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/apis/bundle/v1alpha1"
-	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/files"
 )
 
-// FakeComponentData is simple fake component data string that should always
-// parse.
-var FakeComponentData = `
-kind: Bundle
-components:
-- apiVersion: bundle.gke.io/v1alpha1
-  kind: Component
-  metadata:
-    name: test-pkg
-  spec:
-    componentName: test-comp
-    version: 0.1.0
-`
+// FakeFileReaderWriter is a fake implementation of FileReaderWriter for unit
+// tests.
+type FakeFileReaderWriter struct {
+	// ReadFiles contains mapping of path-to-file for files to-read. If
+	// AlwaysRead is empty and the a path is supplied to read that is not in the
+	// ReadFiles, an error will be returned.
+	ReadFiles map[string]string
 
-// FakeReaderWriter is a fake implementation of FileReaderWriter for unit
-// tests. If a path is not in the PathToFiles, both reads and writes will fail.
-type FakeReaderWriter struct {
-	PathToFiles map[string]string
+	// If AlwaysRead is present, always return the always read object.
+	AlwaysRead string
+
+	// ReadErr forces an error to occur during read.
+	ReadErr error
+
+	// WriteFiles records what files have been written
+	WriteFiles map[string]string
+
+	// WriteErr forces an error to occur during write.
+	WriteErr error
 }
 
-// NewEmptyReaderWriter creates an empty FakeReaderWriter. It will return an
-// error on all paths returned from reads and writes.
-func NewEmptyReaderWriter() *FakeReaderWriter {
-	return &FakeReaderWriter{make(map[string]string)}
-}
-
-// NewFakeReaderWriter returns a FakeReaderWriter that will fake a successful read/write when the
-// given validFile is passed into the ReadBundleFile or WriteBundleFile functions.
-func NewFakeReaderWriter(files map[string]string) *FakeReaderWriter {
-	return &FakeReaderWriter{files}
+// NewEmptyReaderWriter creates an empty FakeFileReaderWriter. It will return an
+// error on all paths returned from reads and succeed on all writes.
+func NewEmptyReaderWriter() *FakeFileReaderWriter {
+	return &FakeFileReaderWriter{
+		ReadFiles:  make(map[string]string),
+		WriteFiles: make(map[string]string),
+	}
 }
 
 // FilePair is a helper for constructing a fake file reader
@@ -68,35 +65,35 @@ func (f *FilePair) String() string {
 	return fmt.Sprintf("{Path: %q  Contents:%s}", f.Path, f.Contents)
 }
 
-// NewFakeReaderWriterFromPairs creates a map based on pairs of string inputs
-func NewFakeReaderWriterFromPairs(pairs ...*FilePair) *FakeReaderWriter {
-	m := make(map[string]string)
-	for _, v := range pairs {
-		m[v.Path] = v.Contents
-	}
-	return NewFakeReaderWriter(m)
+// AddReadFile adds a file to the ReadFiles map.
+func (f *FakeFileReaderWriter) AddReadFile(fp *FilePair) {
+	f.ReadFiles[fp.Path] = fp.Contents
 }
 
 // ReadFile reads a file from the map
-func (f *FakeReaderWriter) ReadFile(_ context.Context, path string) ([]byte, error) {
-	if contents, ok := f.PathToFiles[path]; ok {
+func (f *FakeFileReaderWriter) ReadFile(_ context.Context, path string) ([]byte, error) {
+	if f.ReadErr != nil {
+		return nil, f.ReadErr
+	}
+	if f.AlwaysRead != "" {
+		return []byte(f.AlwaysRead), nil
+	}
+	if contents, ok := f.ReadFiles[path]; ok {
 		return []byte(contents), nil
 	}
 	return nil, fmt.Errorf("error reading bundle file: path not found %q", path)
 }
 
-// ReadFileObj reads a File proto object by deferring to the internal map.
-func (f *FakeReaderWriter) ReadFileObj(ctx context.Context, file bundle.File) ([]byte, error) {
+// ReadFileObj reads a File object by deferring to the internal map.
+func (f *FakeFileReaderWriter) ReadFileObj(ctx context.Context, file bundle.File) ([]byte, error) {
 	return f.ReadFile(ctx, file.URL)
 }
 
 // WriteFile checks write conditions based on path contents.
-func (f *FakeReaderWriter) WriteFile(_ context.Context, path string, bytes []byte, permissions os.FileMode) error {
-	_, ok := f.PathToFiles[path]
-	if !ok {
-		return fmt.Errorf("error writing file: path not found %q ", path)
+func (f *FakeFileReaderWriter) WriteFile(_ context.Context, path string, contents []byte, permissions os.FileMode) error {
+	if f.WriteErr != nil {
+		return f.WriteErr
 	}
+	f.WriteFiles[path] = string(contents)
 	return nil
 }
-
-var _ files.FileReaderWriter = &FakeReaderWriter{}


### PR DESCRIPTION
This PR adds an integration test framework for commands by mocking out
stdio, fileio, and exiting. Additionally I refactored the bundleio test
slightly to use the new fakes and I used the integration test framework
for the easiest command: `bundlectl version`.

Still to do:

- Use the CmdIO struct everywhere.
- Make more integration tests.

Partial work on #126