### PR TITLE
Add a multi-applier applier

### DIFF
--- a/pkg/options/gotmpl/go_template_applier.go
+++ b/pkg/options/gotmpl/go_template_applier.go
@@ -43,7 +43,7 @@ var (
 // inlined as part of the component inlining process.
 type applier struct{}
 
-// NewApplier creates a new optionts applier instance.
+// NewApplier creates a new options applier instance.
 func NewApplier() options.Applier {
 	return &applier{}
 }

--- a/pkg/options/multi/BUILD.bazel
+++ b/pkg/options/multi/BUILD.bazel
@@ -1,0 +1,21 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["multi.go"],
+    importpath = "github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/options/multi",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/apis/bundle/v1alpha1:go_default_library",
+        "//pkg/options:go_default_library",
+        "//pkg/options/gotmpl:go_default_library",
+        "//pkg/options/patchtmpl:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["multi_test.go"],
+    embed = [":go_default_library"],
+    deps = ["//pkg/converter:go_default_library"],
+)

--- a/pkg/options/multi/multi.go
+++ b/pkg/options/multi/multi.go
@@ -1,0 +1,54 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package multi is an applier that performs multiple different applier
+// approaches.
+package multi
+
+import (
+	bundle "github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/apis/bundle/v1alpha1"
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/options"
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/options/gotmpl"
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/options/patchtmpl"
+)
+
+type applier struct {
+	appliers []options.Applier
+}
+
+// NewApplier creates a new multi applier instance.
+func NewApplier(appliers []options.Applier) options.Applier {
+	return &applier{appliers: appliers[:]}
+}
+
+// NewDefaultApplier creates a default multi-applier
+func NewDefaultApplier() options.Applier {
+	return NewApplier([]options.Applier{
+		gotmpl.NewApplier(),
+		patchtmpl.NewDefaultApplier(),
+	})
+}
+
+// ApplyOptions by going through the appliers in order.
+func (m *applier) ApplyOptions(comp *bundle.Component, opts options.JSONOptions) (*bundle.Component, error) {
+	comp = comp.DeepCopy()
+	for _, a := range m.appliers {
+		c, err := a.ApplyOptions(comp, opts)
+		if err != nil {
+			return nil, err
+		}
+		comp = c
+	}
+	return comp, nil
+}

--- a/pkg/options/multi/multi_test.go
+++ b/pkg/options/multi/multi_test.go
@@ -1,0 +1,100 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multi
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/converter"
+)
+
+func TestMultiApply(t *testing.T) {
+	component := `
+kind: Component
+spec:
+  objects:
+  - apiVersion: apps/v1beta1
+    kind: Deployment
+    metadata:
+      namespace: foo
+  - kind: ObjectTemplate
+    type: go-template
+    template: |
+      apiVersion: v1
+      kind: Pod
+      metadata:
+        name: logger-pod
+      spec:
+        dnsPolicy: {{.DNSPolicy}}
+        containers:
+        - name: logger
+          image: {{.ContainerImage}}
+  - kind: PatchTemplate
+    template: |
+      kind: Deployment
+      metadata:
+        namespace: bar
+  - kind: PatchTemplate
+    template: |
+      kind: Pod
+      metadata:
+        namespace: {{.PodNamespace}}
+`
+
+	opts := map[string]interface{}{
+		"DNSPolicy":      "somePolicy",
+		"ContainerImage": "gcr.io/foobar:latest",
+		"PodNamespace":   "zed",
+		"Unused":         "unused",
+	}
+
+	expStrs := []string{"namespace: zed", "dnsPolicy: somePolicy", "image: gcr.io/foobar:latest", "namespace: bar"}
+	notExpStrs := []string{"unused", "namespace: foo", "PatchTemplate", "{{"}
+
+	comp, err := converter.FromYAMLString(component).ToComponent()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	newComp, err := NewDefaultApplier().ApplyOptions(comp, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	newCompStr, err := converter.FromObject(newComp).ToYAMLString()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	hasErr := false
+	for _, e := range expStrs {
+		if !strings.Contains(newCompStr, e) {
+			t.Errorf("expected component to contain string %q", e)
+			hasErr = true
+		}
+	}
+
+	for _, e := range notExpStrs {
+		if strings.Contains(newCompStr, e) {
+			t.Errorf("expected component to *not* contain string %q", e)
+			hasErr = true
+		}
+	}
+
+	if hasErr {
+		t.Errorf("got component\n%s", newCompStr)
+	}
+}


### PR DESCRIPTION
This allows chaining together appliers. By default, options are first
applied to go templates, and then patches are applied. This is a good
default ordering because it means patches can be later applied to go
templates.

Fixes: #249