### PR TITLE
Add a dependency solver

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -26,6 +26,14 @@
   version = "v9"
 
 [[projects]]
+  digest = "1:705c40022f5c03bf96ffeb6477858d88565064485a513abcd0f11a0911546cb6"
+  name = "github.com/blang/semver"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "2ee87856327ba09384cabd113bc6b5d174e9ec0f"
+  version = "v3.5.1"
+
+[[projects]]
   digest = "1:ffe9824d294da03b391f44e1ae8281281b4afc1bdaa9588c9097785e3af10cec"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
@@ -539,6 +547,7 @@
   analyzer-version = 1
   input-imports = [
     "github.com/evanphx/json-patch",
+    "github.com/blang/semver",
     "github.com/ghodss/yaml",
     "github.com/go-openapi/spec",
     "github.com/go-openapi/strfmt",

--- a/config/crds/bundle_v1alpha1_bundle.yaml
+++ b/config/crds/bundle_v1alpha1_bundle.yaml
@@ -40,20 +40,6 @@ spec:
               spec:
                 description: The specification object for the Component.
                 properties:
-                  appVersion:
-                    description: AppVersion specifies the application version that
-                      the component provides and should have the form X.Y or X.Y.Z
-                      (Major.Minor.Patch). The AppVersion will frequently be related
-                      to the version of the container image used by the application
-                      and need not be updated when a component Version field is updated,
-                      unless the application contract changes.  For example, for an
-                      Etcd component, the version field might be something like 10.9.8,
-                      but the app version would probalby be something like 3.3.10,
-                      representing the version of Etcd application.  In order for
-                      component A to depend on component B, component B must specify
-                      a Requirements object with an AppVersion. Eliding the AppVersion
-                      prevents other components from depending on your component.
-                    type: string
                   componentName:
                     description: ComponentName is the canonical name of this component.
                       For example, 'etcd' or 'kube-proxy'. It must have the same naming

--- a/config/crds/bundle_v1alpha1_component.yaml
+++ b/config/crds/bundle_v1alpha1_component.yaml
@@ -29,19 +29,6 @@ spec:
         spec:
           description: The specification object for the Component.
           properties:
-            appVersion:
-              description: AppVersion specifies the application version that the component
-                provides and should have the form X.Y or X.Y.Z (Major.Minor.Patch).
-                The AppVersion will frequently be related to the version of the container
-                image used by the application and need not be updated when a component
-                Version field is updated, unless the application contract changes.  For
-                example, for an Etcd component, the version field might be something
-                like 10.9.8, but the app version would probalby be something like
-                3.3.10, representing the version of Etcd application.  In order for
-                component A to depend on component B, component B must specify a Requirements
-                object with an AppVersion. Eliding the AppVersion prevents other components
-                from depending on your component.
-              type: string
             componentName:
               description: ComponentName is the canonical name of this component.
                 For example, 'etcd' or 'kube-proxy'. It must have the same naming

--- a/config/crds/bundle_v1alpha1_componentbuilder.yaml
+++ b/config/crds/bundle_v1alpha1_componentbuilder.yaml
@@ -19,19 +19,6 @@ spec:
             of an object. Servers should convert recognized schemas to the latest
             internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
           type: string
-        appVersion:
-          description: AppVersion specifies the application version that the component
-            provides and should have the form X.Y or X.Y.Z (Major.Minor.Patch). The
-            AppVersion will frequently be related to the version of the container
-            image used by the application and need not be updated when a component
-            Version field is updated, unless the application contract changes.  For
-            example, for an Etcd component, the version field might be something like
-            10.9.8, but the app version would probalby be something like 3.3.10, representing
-            the version of Etcd application.  In order for component A to depend on
-            component B, component B must specify a Requirements object with an AppVersion.
-            Eliding the AppVersion prevents other components from depending on your
-            component.
-          type: string
         componentName:
           description: ComponentName is the canonical name of this component. See
             ComponentSpec.ComponentName for more details.

--- a/config/crds/bundle_v1alpha1_requirements.yaml
+++ b/config/crds/bundle_v1alpha1_requirements.yaml
@@ -27,21 +27,20 @@ spec:
         metadata:
           type: object
         require:
-          description: Require specific component versions. A component that with
-            an AppVersion >= to the AppVersion specified by a component may satisfy
-            this requirement, using minimal version selection or a similar algorithm.
+          description: Require specifies components that must be packaged with this
+            component.
           items:
             properties:
-              appVersion:
-                description: AppVersion specifies the minimum required AppVersion
-                  present in another components Requirements object. In otherwords,
-                  the AppVersion given by ComponentName in a Bundle or Set must be
-                  >= to this AppVersion, fixing the major version.  If AppVersion
-                  is not included, then any component with the specified ComponentName
-                  will be considered a valid match.
-                type: string
               componentName:
                 description: ComponentName (required) specifies the name of a component.
+                type: string
+              version:
+                description: Version specifies the minimum required version present
+                  in another components Requirements object. In otherwords, the Version
+                  given by ComponentName in a Bundle or Set must be >= to this version,
+                  fixing the major version.  If version is not included, then any
+                  component with the specified ComponentName will be considered a
+                  valid match.
                 type: string
             type: object
           type: array

--- a/pkg/apis/bundle/v1alpha1/builder_types.go
+++ b/pkg/apis/bundle/v1alpha1/builder_types.go
@@ -61,21 +61,6 @@ type ComponentBuilder struct {
 	// more details. The version is optional for the ComponentBuilder.
 	Version string `json:"version,omitempty"`
 
-	// AppVersion specifies the application version that the component provides
-	// and should have the form X.Y or X.Y.Z (Major.Minor.Patch). The AppVersion
-	// will frequently be related to the version of the container image used by
-	// the application and need not be updated when a component Version field is
-	// updated, unless the application contract changes.
-	//
-	// For example, for an Etcd component, the version field might be something
-	// like 10.9.8, but the app version would probalby be something like 3.3.10,
-	// representing the version of Etcd application.
-	//
-	// In order for component A to depend on component B, component B must
-	// specify a Requirements object with an AppVersion. Eliding the AppVersion
-	// prevents other components from depending on your component.
-	AppVersion string `json:"appVersion,omitempty"`
-
 	// Objects that are specified via a File-URL. The process of inlining a
 	// component turns object files into objects.  During the inline process, if
 	// the file is YAML-formatted and contains multiple objects in the YAML-doc,

--- a/pkg/apis/bundle/v1alpha1/component_types.go
+++ b/pkg/apis/bundle/v1alpha1/component_types.go
@@ -75,21 +75,6 @@ type ComponentSpec struct {
 	// changes to the component, then the version string must be incremented.
 	Version string `json:"version,omitempty"`
 
-	// AppVersion specifies the application version that the component provides
-	// and should have the form X.Y or X.Y.Z (Major.Minor.Patch). The AppVersion
-	// will frequently be related to the version of the container image used by
-	// the application and need not be updated when a component Version field is
-	// updated, unless the application contract changes.
-	//
-	// For example, for an Etcd component, the version field might be something
-	// like 10.9.8, but the app version would probalby be something like 3.3.10,
-	// representing the version of Etcd application.
-	//
-	// In order for component A to depend on component B, component B must
-	// specify a Requirements object with an AppVersion. Eliding the AppVersion
-	// prevents other components from depending on your component.
-	AppVersion string `json:"appVersion,omitempty"`
-
 	// Structured Kubenetes objects that run as part of this app, whether on the
 	// master, on the nodes, or in some other fashio.  These Kubernetes objects
 	// are inlined and must be YAML/JSON compatible. Each must have `apiVersion`,

--- a/pkg/apis/bundle/v1alpha1/requirement_types.go
+++ b/pkg/apis/bundle/v1alpha1/requirement_types.go
@@ -23,20 +23,39 @@ import (
 // Requirements specifies the packaging-time dependencies for an encapsulating
 // Component object. The term 'packaging-time' is meant to distinguish from
 // compile or runtime dependencies, and refers to the idea that when building a
-// set of components, the Requirements are checked to ensure that the set
+// collection of components, the Requirements are checked to ensure that the set
 // of components is valid. Additionally, the Requirements may be used to
-// construct the set of copmonents by selecting the appropriate components
+// construct the set of components by selecting the appropriate components
 // from a universe of available components.
 //
-// The structure and terminology is based on Go Modules. For a detailed
-// discussion of Go Modules see: https://github.com/golang/go/wiki/Module.
+// Only one requirements object can be specified in a component.
 type Requirements struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	// Require specific component versions. A component that with an AppVersion
-	// >= to the AppVersion specified by a component may satisfy this
-	// requirement, using minimal version selection or a similar algorithm.
+	// Visibility indicates which components can depend on this component.
+	//
+	// If not specified, the component defaults to being 'private' -- other
+	// components cannot depend on this component.
+	//
+	// There are several reserved names (which are anyways illegal as component names):
+	//
+	//    @public: visible to all components.
+	//    @private: not visible for other components to depend on. This is the default.
+	//
+	// If either @public or @private are specified, these rules override all
+	// other component rules.
+	//
+	// Visibility can be broadened with new versions of components, for example,
+	// by going from private to granting visibility to specific components or
+	// event to public. However, it's it's not supported to narrow visibility,
+	// for example, by going from public to private. Doing so may result in
+	// previous component versions not being accessible based on the new
+	// visibility rules.  To narrow visibility, it's recommended to create a
+	// new component -- my-component-v2.
+	Visibility []string `json:"visibility,omitempty`
+
+	// Require specifies components that must be packaged with this component.
 	Require []ComponentRequire `json:"require,omitempty"`
 }
 
@@ -46,12 +65,12 @@ type ComponentRequire struct {
 	// ComponentName (required) specifies the name of a component.
 	ComponentName string `json:"componentName,omitempty"`
 
-	// AppVersion specifies the minimum required AppVersion present in another
-	// components Requirements object. In otherwords, the AppVersion given by
-	// ComponentName in a Bundle or Set must be >= to this AppVersion, fixing the
+	// Version specifies the minimum required version present in another
+	// components Requirements object. In otherwords, the Version given by
+	// ComponentName in a Bundle or Set must be >= to this version, fixing the
 	// major version.
 	//
-	// If AppVersion is not included, then any component with the specified
+	// If version is not included, then any component with the specified
 	// ComponentName will be considered a valid match.
-	AppVersion string `json:"appVersion,omitempty"`
+	Version string `json:"version,omitempty"`
 }

--- a/pkg/apis/bundle/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/bundle/v1alpha1/zz_generated.deepcopy.go
@@ -620,6 +620,11 @@ func (in *Requirements) DeepCopyInto(out *Requirements) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
 	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
+	if in.Visibility != nil {
+		in, out := &in.Visibility, &out.Visibility
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.Require != nil {
 		in, out := &in.Require, &out.Require
 		*out = make([]ComponentRequire, len(*in))

--- a/pkg/build/inline.go
+++ b/pkg/build/inline.go
@@ -174,7 +174,6 @@ func (n *Inliner) ComponentFiles(ctx context.Context, comp *bundle.ComponentBuil
 		Spec: bundle.ComponentSpec{
 			ComponentName: comp.ComponentName,
 			Version:       comp.Version,
-			AppVersion:    comp.AppVersion,
 			Objects:       newObjs,
 		},
 	}

--- a/pkg/deps/BUILD.bazel
+++ b/pkg/deps/BUILD.bazel
@@ -3,8 +3,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
+        "annotation_matcher.go",
         "collate.go",
         "latest.go",
+        "matcher.go",
         "meta.go",
         "resolve.go",
     ],
@@ -20,6 +22,7 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = [
+        "annotation_matcher_test.go",
         "collate_test.go",
         "meta_test.go",
         "resolve_test.go",

--- a/pkg/deps/BUILD.bazel
+++ b/pkg/deps/BUILD.bazel
@@ -1,0 +1,34 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "collate.go",
+        "latest.go",
+        "meta.go",
+        "resolve.go",
+    ],
+    importpath = "github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/deps",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/apis/bundle/v1alpha1:go_default_library",
+        "//pkg/converter:go_default_library",
+        "//vendor/github.com/blang/semver:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "collate_test.go",
+        "meta_test.go",
+        "resolve_test.go",
+    ],
+    embed = [":go_default_library"],
+    deps = [
+        "//pkg/apis/bundle/v1alpha1:go_default_library",
+        "//pkg/converter:go_default_library",
+        "//pkg/testutil:go_default_library",
+        "//vendor/github.com/blang/semver:go_default_library",
+    ],
+)

--- a/pkg/deps/annotation_matcher.go
+++ b/pkg/deps/annotation_matcher.go
@@ -46,8 +46,9 @@ type AnnotationCriteria struct {
 	// present. In other words, given values A, B, C for Annotation K, the logic
 	// is equivalent to A || B || C).
 	//
-	// In other words, this is a logical AND operation of the passed in Annotation and
-	// the component Annotation.
+	// If there are multiple keys (annotations) specified, then all annotations
+	// must match.  In other words, this is a logical AND operation of the passed
+	// in Annotation and the component Annotation.
 	Match map[string][]string
 
 	// Exclude are component annotations that must not be present.  This is
@@ -55,8 +56,9 @@ type AnnotationCriteria struct {
 	// component passed qualification). If any of the the list of values match,
 	// the component is excluded.
 	//
-	// In other words, this is a logical NAND operation of the passed in
-	// Annotation and the component Annotation.
+	// Unlike Match, if a there are multiple keys (annotations) specified, then
+	// only one of the annotations need be matched in order for the component to
+	// be excluded.
 	Exclude map[string][]string
 }
 

--- a/pkg/deps/annotation_matcher.go
+++ b/pkg/deps/annotation_matcher.go
@@ -1,0 +1,113 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deps
+
+import (
+	bundle "github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/apis/bundle/v1alpha1"
+)
+
+// Below is a worked example of a matcher using the annotations on the
+// component itself.
+
+// AnnotationMetadata contains annotation metadata, used for matching against
+// components.
+type AnnotationMetadata struct {
+	Annotations map[string]string
+}
+
+// AnnotationProcessor extracts annotations from a component, to be used for Matching
+func AnnotationProcessor(c *bundle.Component) (MatchMetadata, error) {
+	am := &AnnotationMetadata{
+		Annotations: make(map[string]string),
+	}
+	for key, val := range c.ObjectMeta.Annotations {
+		am.Annotations[key] = val
+	}
+	return am, nil
+}
+
+// AnnotationCriteria are options for resolving dependencies
+type AnnotationCriteria struct {
+	// Match are component annotations that must to be present. This is useful
+	// for matching positive characteristics of a component (example: this
+	// component passed qualification). Only one of the list of values need be
+	// present. In other words, given values A, B, C for Annotation K, the logic
+	// is equivalent to A || B || C).
+	//
+	// In other words, this is a logical AND operation of the passed in Annotation and
+	// the component Annotation.
+	Match map[string][]string
+
+	// Exclude are component annotations that must not be present.  This is
+	// useful for matching positive characteristics of a component (this
+	// component passed qualification). If any of the the list of values match,
+	// the component is excluded.
+	//
+	// In other words, this is a logical NAND operation of the passed in
+	// Annotation and the component Annotation.
+	Exclude map[string][]string
+}
+
+// AnnotationMatcher constructs a Matcher that relies on a components annotations.
+func AnnotationMatcher(criteria *AnnotationCriteria) Matcher {
+	return func(ref bundle.ComponentReference, mm MatchMetadata) bool {
+		if mm == nil {
+			return true
+		}
+
+		m, ok := mm.(*AnnotationMetadata)
+		if !ok {
+			return true
+		}
+
+		matchesAnnot := func(key string, vals []string, annots map[string]string) bool {
+			matchesAny := false
+			for _, val := range vals {
+				if m.Annotations[key] == val {
+					matchesAny = true
+					break
+				}
+			}
+			return matchesAny
+		}
+
+		match := true
+		for key, vals := range criteria.Match {
+			if !matchesAnnot(key, vals, m.Annotations) {
+				match = false
+				break
+			}
+		}
+
+		exclude := false
+		for key, vals := range criteria.Exclude {
+			if matchesAnnot(key, vals, m.Annotations) {
+				exclude = true
+				break
+			}
+		}
+		return match && !exclude
+	}
+}
+
+// sliceContains is a helper to indicate whethera slice of strings contains a string.
+func sliceContains(ls []string, st string) bool {
+	for _, s := range ls {
+		if s == st {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/deps/annotation_matcher_test.go
+++ b/pkg/deps/annotation_matcher_test.go
@@ -1,0 +1,17 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deps
+
+// TODO(kashomon): add tests.

--- a/pkg/deps/annotation_matcher_test.go
+++ b/pkg/deps/annotation_matcher_test.go
@@ -14,4 +14,157 @@
 
 package deps
 
-// TODO(kashomon): add tests.
+import (
+	"reflect"
+	"testing"
+
+	bundle "github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/apis/bundle/v1alpha1"
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/converter"
+)
+
+var annotProcessingComps = []string{
+	`
+kind: Component
+metadata:
+spec:
+  componentName: ann-none
+  version: 1.0.0
+`,
+	`
+kind: Component
+metadata:
+  annotations:
+    cool-component: true
+    qualified: true
+    channel: stable
+spec:
+  componentName: ann
+  version: 1.0.0
+`,
+	`
+kind: Component
+metadata:
+  annotations:
+    cool-component: true
+    qualified: true
+    bad-component: true
+    feature: biff
+    channel: beta
+spec:
+  componentName: ann
+  version: 1.1.0
+`,
+	`
+kind: Component
+metadata:
+  annotations:
+    cool-component: true
+    feature: bar
+    channel: alpha
+spec:
+  componentName: ann
+  version: 1.2.0
+`,
+}
+
+func TestAnnotationProcessor(t *testing.T) {
+	testCases := []struct {
+		desc   string
+		ref    bundle.ComponentReference
+		annots map[string]string
+	}{
+		{
+			desc: "ann-1.0.0",
+			ref: bundle.ComponentReference{
+				ComponentName: "ann",
+				Version:       "1.0.0",
+			},
+			annots: map[string]string{
+				"cool-component": "true",
+				"qualified":      "true",
+				"channel":        "stable",
+			},
+		}, {
+			desc: "ann-none-1.0.0",
+			ref: bundle.ComponentReference{
+				ComponentName: "ann-none",
+				Version:       "1.0.0",
+			},
+			annots: map[string]string{},
+		},
+	}
+	comps := make(map[bundle.ComponentReference]*bundle.Component)
+	for _, c := range annotProcessingComps {
+		comp, err := converter.FromYAMLString(c).ToComponent()
+		if err != nil {
+			t.Fatal(err)
+		}
+		comps[comp.ComponentReference()] = comp
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			mm, err := AnnotationProcessor(comps[tc.ref])
+			if err != nil {
+				t.Fatal(err)
+			}
+			meta, ok := mm.(*AnnotationMetadata)
+			if !ok {
+				t.Fatal("could not cast to AnnotationMetadata")
+			}
+			if !reflect.DeepEqual(tc.annots, meta.Annotations) {
+				t.Errorf("processed annotations: got %v, but expected %v", meta.Annotations, tc.annots)
+			}
+		})
+	}
+}
+
+func TestAnnotationMatcher(t *testing.T) {
+	testCases := []struct {
+		desc     string
+		ref      bundle.ComponentReference
+		criteria *AnnotationCriteria
+		expMatch bool
+	}{
+		{
+			desc: "ann-1.0.0, match",
+			ref: bundle.ComponentReference{
+				ComponentName: "ann",
+				Version:       "1.0.0",
+			},
+			criteria: &AnnotationCriteria{
+				Match: map[string][]string{
+					"channel": []string{"stable"},
+				},
+			},
+			expMatch: true,
+		},
+	}
+	comps := make(map[bundle.ComponentReference]*bundle.Component)
+	for _, c := range annotProcessingComps {
+		comp, err := converter.FromYAMLString(c).ToComponent()
+		if err != nil {
+			t.Fatal(err)
+		}
+		comps[comp.ComponentReference()] = comp
+	}
+
+	metadata := make(map[bundle.ComponentReference]MatchMetadata)
+	for _, c := range comps {
+		mm, err := AnnotationProcessor(c)
+		if err != nil {
+			t.Fatal(err)
+		}
+		metadata[c.ComponentReference()] = mm
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			mm, ok := metadata[tc.ref]
+			if !ok {
+				t.Fatalf("no metadata for ref %v", tc.ref)
+			}
+			if matched := AnnotationMatcher(tc.criteria)(tc.ref, mm); matched != tc.expMatch {
+				t.Fatalf("for ref %v and criteria %v, got match %t but expected %t", tc.ref, tc.criteria, matched, tc.expMatch)
+			}
+		})
+	}
+}

--- a/pkg/deps/annotation_matcher_test.go
+++ b/pkg/deps/annotation_matcher_test.go
@@ -126,6 +126,15 @@ func TestAnnotationMatcher(t *testing.T) {
 		expMatch bool
 	}{
 		{
+			desc: "ann-1.0.0, no criteria match",
+			ref: bundle.ComponentReference{
+				ComponentName: "ann",
+				Version:       "1.0.0",
+			},
+			criteria: &AnnotationCriteria{},
+			expMatch: true,
+		},
+		{
 			desc: "ann-1.0.0, match",
 			ref: bundle.ComponentReference{
 				ComponentName: "ann",
@@ -137,6 +146,138 @@ func TestAnnotationMatcher(t *testing.T) {
 				},
 			},
 			expMatch: true,
+		},
+		{
+			desc: "ann-1.0.0, no match",
+			ref: bundle.ComponentReference{
+				ComponentName: "ann",
+				Version:       "1.0.0",
+			},
+			criteria: &AnnotationCriteria{
+				Match: map[string][]string{
+					"channel": []string{"unstable"},
+				},
+			},
+			expMatch: false,
+		},
+		{
+			desc: "ann-1.0.0, multi match",
+			ref: bundle.ComponentReference{
+				ComponentName: "ann",
+				Version:       "1.0.0",
+			},
+			criteria: &AnnotationCriteria{
+				Match: map[string][]string{
+					"channel": []string{"stable", "unstable"},
+				},
+			},
+			expMatch: true,
+		},
+		{
+			desc: "ann-1.0.0, both match",
+			ref: bundle.ComponentReference{
+				ComponentName: "ann",
+				Version:       "1.0.0",
+			},
+			criteria: &AnnotationCriteria{
+				Match: map[string][]string{
+					"channel":   []string{"stable", "unstable"},
+					"qualified": []string{"true"},
+				},
+			},
+			expMatch: true,
+		},
+		{
+			desc: "ann-1.0.0, both match",
+			ref: bundle.ComponentReference{
+				ComponentName: "ann",
+				Version:       "1.0.0",
+			},
+			criteria: &AnnotationCriteria{
+				Match: map[string][]string{
+					"channel":   []string{"stable", "unstable"},
+					"qualified": []string{"true"},
+				},
+			},
+			expMatch: true,
+		},
+		{
+			desc: "ann-none-1.0.0, match, no annotations",
+			ref: bundle.ComponentReference{
+				ComponentName: "ann-none",
+				Version:       "1.0.0",
+			},
+			criteria: &AnnotationCriteria{},
+			expMatch: true,
+		},
+		{
+			desc: "ann-none-1.0.0, no match, no annotations",
+			ref: bundle.ComponentReference{
+				ComponentName: "ann-none",
+				Version:       "1.0.0",
+			},
+			criteria: &AnnotationCriteria{
+				Match: map[string][]string{
+					"channel": []string{"stable"},
+				},
+			},
+			expMatch: false,
+		},
+		{
+			desc: "ann-none-1.0.0, no exclude, no annotations",
+			ref: bundle.ComponentReference{
+				ComponentName: "ann-none",
+				Version:       "1.0.0",
+			},
+			criteria: &AnnotationCriteria{
+				Exclude: map[string][]string{
+					"channel": []string{"stable"},
+				},
+			},
+			expMatch: true,
+		},
+		{
+			desc: "ann-1.0.0, exclude, annotations",
+			ref: bundle.ComponentReference{
+				ComponentName: "ann",
+				Version:       "1.0.0",
+			},
+			criteria: &AnnotationCriteria{
+				Exclude: map[string][]string{
+					"channel": []string{"stable"},
+				},
+			},
+			expMatch: false,
+		},
+		{
+			desc: "ann-1.0.0, multi exclude - only one required",
+			ref: bundle.ComponentReference{
+				ComponentName: "ann",
+				Version:       "1.0.0",
+			},
+			criteria: &AnnotationCriteria{
+				Exclude: map[string][]string{
+					"channel": []string{"stable"},
+					"zorp":    []string{"derp"},
+				},
+			},
+			expMatch: false,
+		},
+		{
+			desc: "ann-1.0.0, both exclude and match: exclude wins ",
+			ref: bundle.ComponentReference{
+				ComponentName: "ann",
+				Version:       "1.0.0",
+			},
+			criteria: &AnnotationCriteria{
+				Match: map[string][]string{
+					"channel": []string{"stable"},
+				},
+				Exclude: map[string][]string{
+					"channel": []string{"stable"},
+				},
+			},
+			expMatch: false,
 		},
 	}
 	comps := make(map[bundle.ComponentReference]*bundle.Component)

--- a/pkg/deps/collate.go
+++ b/pkg/deps/collate.go
@@ -1,0 +1,188 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deps
+
+import (
+	"fmt"
+	"sort"
+
+	bundle "github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/apis/bundle/v1alpha1"
+	"github.com/blang/semver"
+)
+
+// searchOpts are options for searching for latest or previous versions. For a
+// more detailed discussion, see the ResolveOptions.
+type searchOpts struct {
+	match          map[string][]string
+	matchIfPresent map[string][]string
+	exclude        map[string][]string
+}
+
+// String returns the stringified search options.
+func (s *searchOpts) String() string {
+	return fmt.Sprintf("{%+v, %+v}", s.match, s.exclude)
+}
+
+// sortedVersions contain all the component versions for a single component,
+// sorted by version. It should be considered immutable and must not be changed
+// once created.
+type sortedVersions struct {
+	componentName string
+
+	// versions contains the versions sorted in ascending order. In otherwords,
+	// versions[0] is the lowest version.
+	versions []*depMeta
+}
+
+// String prints the stringified components.
+func (s *sortedVersions) String() string {
+	out := fmt.Sprintf("{%s", s.componentName)
+	for i, v := range s.versions {
+		out += " "
+		if i == 0 {
+			out += "["
+		}
+		out += v.version.String()
+		if i == len(s.versions)-1 {
+			out += "]"
+		}
+	}
+	return out + "}"
+}
+
+// useComponent evaluates whether, based on the searchOpts, the component
+// should be used.
+func (s *sortedVersions) useComponent(m *depMeta, opts *searchOpts) bool {
+	if opts == nil {
+		return true
+	}
+
+	match := true
+	for k, vals := range opts.match {
+		matchesOne := false
+		for i := range vals {
+			if m.annotations[k] == vals[i] {
+				matchesOne = true
+				break
+			}
+		}
+		if !matchesOne {
+			match = false
+			break
+		}
+	}
+
+	matchIfPresent := true
+	for k, vals := range opts.matchIfPresent {
+		matchesOne := false
+		for i := range vals {
+			if val, ok := m.annotations[k]; !ok || val == vals[i] {
+				matchesOne = true
+				break
+			}
+		}
+		if !matchesOne {
+			matchIfPresent = false
+			break
+		}
+	}
+
+	exclude := false
+	for k, vals := range opts.exclude {
+		matchesOne := false
+		for i := range vals {
+			if m.annotations[k] == vals[i] {
+				matchesOne = true
+				break
+			}
+		}
+		if matchesOne {
+			exclude = true
+			break
+		}
+	}
+	return match && matchIfPresent && !exclude
+}
+
+// latest gets the latest depMeta version for a component, given some
+// annotation criteria, or returns an error if no latest version is
+// available.
+func (s *sortedVersions) latest(opts *searchOpts) (*depMeta, error) {
+	for i := len(s.versions) - 1; i >= 0; i-- {
+		ver := s.versions[i]
+		if s.useComponent(ver, opts) {
+			return ver, nil
+		}
+	}
+	return nil, fmt.Errorf("for component %s, no latest version matching criteria %v", s.componentName, opts)
+}
+
+// Previous gets the version previous to a specific version, given some
+// annotation criteria, or returns an error if no previous version is
+// available.
+func (s *sortedVersions) previous(ver semver.Version, opts *searchOpts) (*depMeta, error) {
+	// This is currently a linear search for clarity. Given the filtering
+	// options, it's not clear if it could be made significantly faster.
+	for i := len(s.versions) - 1; i >= 0; i-- {
+		m := s.versions[i]
+		if m.version.LT(ver) && s.useComponent(m, opts) {
+			return m, nil
+		}
+	}
+	return nil, fmt.Errorf("for component %s, no previous version to %v matching criteria %v", s.componentName, ver, opts)
+}
+
+// sortedMapFromComponents creates a map from component name to meta.
+func sortedMapFromComponents(comps []*bundle.Component) (map[string]*sortedVersions, map[bundle.ComponentReference]*depMeta, error) {
+	allMetas := make(map[string][]*depMeta)
+	lookupMap := make(map[bundle.ComponentReference]*depMeta)
+	for _, c := range comps {
+		m, err := metaFromComponent(c)
+		if err != nil {
+			return nil, nil, err
+		}
+		if _, ok := allMetas[m.componentName]; !ok {
+			allMetas[m.componentName] = []*depMeta{m}
+		} else {
+			allMetas[m.componentName] = append(allMetas[m.componentName], m)
+		}
+		if lookupMap[c.ComponentReference()] != nil {
+			return nil, nil, fmt.Errorf("duplicate component %v", c.ComponentReference())
+		}
+		lookupMap[c.ComponentReference()] = m
+	}
+
+	sortedMap := make(map[string]*sortedVersions)
+	for name, metas := range allMetas {
+		sortedMap[name] = &sortedVersions{
+			componentName: name,
+			versions:      orderByVersion(metas),
+		}
+	}
+	return sortedMap, lookupMap, nil
+}
+
+// orderByVersion sorts the meta objects by version, in descending order
+// (latest first).
+//
+// This method assumes that the list of metas is already been
+// collated so it contains just the metas for a single component.
+func orderByVersion(m []*depMeta) []*depMeta {
+	m = m[:]
+	sort.Slice(m, func(i, j int) bool {
+		return m[i].version.LT(m[j].version)
+	})
+	return m
+}

--- a/pkg/deps/collate_test.go
+++ b/pkg/deps/collate_test.go
@@ -1,0 +1,462 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deps
+
+import (
+	"testing"
+
+	bundle "github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/apis/bundle/v1alpha1"
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/converter"
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/testutil"
+	"github.com/blang/semver"
+)
+
+var defaultCollateComponents = []string{
+	`
+kind: Component
+spec:
+  componentName: foo
+  version: 1.0.1
+`,
+	`
+kind: Component
+spec:
+  componentName: foo
+  version: 1.0.2
+`,
+	`
+kind: Component
+spec:
+  componentName: foo
+  version: 1.0.3
+`,
+	`
+kind: Component
+spec:
+  componentName: foo
+  version: 1.0.4
+`,
+	`
+kind: Component
+spec:
+  componentName: foo
+  version: 1.3.4
+`,
+	`
+kind: Component
+spec:
+  componentName: foo
+  version: 2.3.4
+`,
+	`
+kind: Component
+spec:
+  componentName: foo
+  version: 2.4.4
+`,
+	`
+kind: Component
+spec:
+  componentName: boo
+  version: 1.0.2
+`,
+
+	`
+kind: Component
+metadata:
+  annotations:
+    cool-component: true
+    qualified: true
+    channel: stable
+spec:
+  componentName: ann
+  version: 1.0.0
+`,
+	`
+kind: Component
+metadata:
+  annotations:
+    cool-component: true
+    qualified: true
+    bad-component: true
+    feature: biff
+    channel: beta
+spec:
+  componentName: ann
+  version: 1.1.0
+`,
+	`
+kind: Component
+metadata:
+  annotations:
+    cool-component: true
+    feature: bar
+    channel: alpha
+spec:
+  componentName: ann
+  version: 1.2.0
+`,
+}
+
+var versionSuffix = []string{
+	`
+kind: Component
+spec:
+  componentName: foo
+  version: 2.3.3-gke.0
+`,
+	`
+kind: Component
+spec:
+  componentName: foo
+  version: 2.3.4-gke.0
+`,
+	`
+kind: Component
+spec:
+  componentName: foo
+  version: 2.3.4-gke.1
+`,
+	`
+kind: Component
+spec:
+  componentName: foo
+  version: 2.3.4-gke.2
+`,
+	`
+kind: Component
+spec:
+  componentName: foo
+  version: 2.3.4-gke.12
+`,
+	`
+kind: Component
+spec:
+  componentName: foo
+  version: 2.4.4
+`,
+}
+
+func TestLatest(t *testing.T) {
+	comps, err := makeComps(defaultCollateComponents)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sorted, _, err := sortedMapFromComponents(comps)
+	if err != nil {
+		t.Fatal(err)
+	}
+	testCases := []struct {
+		desc          string
+		componentName string
+		opts          *searchOpts
+
+		expOut       string
+		expErrSubstr string
+	}{
+		{
+			desc:          "found latest",
+			componentName: "foo",
+			expOut:        "2.4.4",
+		},
+		{
+			desc:          "found latest, boo",
+			componentName: "boo",
+			expOut:        "1.0.2",
+		},
+
+		{
+			desc:          "annotations",
+			componentName: "ann",
+			expOut:        "1.2.0",
+		},
+		{
+			desc:          "annotations",
+			componentName: "ann",
+			expOut:        "1.2.0",
+		},
+		{
+			desc:          "annotations, match criteria all",
+			componentName: "ann",
+			expOut:        "1.2.0",
+			opts: &searchOpts{
+				match: map[string][]string{
+					"cool-component": []string{"true"},
+				},
+			},
+		},
+		{
+			desc:          "annotations, match criteria subset",
+			componentName: "ann",
+			expOut:        "1.1.0",
+			opts: &searchOpts{
+				match: map[string][]string{
+					"qualified": []string{"true"},
+				},
+			},
+		},
+		{
+			desc:          "annotations, match exactly one channel",
+			componentName: "ann",
+			expOut:        "1.0.0",
+			opts: &searchOpts{
+				match: map[string][]string{
+					"channel": []string{"stable"},
+				},
+			},
+		},
+		{
+			desc:          "annotations, match one of two channels",
+			componentName: "ann",
+			expOut:        "1.1.0",
+			opts: &searchOpts{
+				match: map[string][]string{
+					"channel": []string{"stable", "beta"},
+				},
+			},
+		},
+		{
+			desc:          "annotations, match and exclude criteria",
+			componentName: "ann",
+			expOut:        "1.0.0",
+			opts: &searchOpts{
+				match: map[string][]string{
+					"qualified": []string{"true"},
+				},
+				exclude: map[string][]string{
+					"bad-component": []string{"true"},
+				},
+			},
+		},
+		{
+			desc:          "annotations, match if present: not present is fine",
+			componentName: "ann",
+			expOut:        "1.2.0",
+			opts: &searchOpts{
+				matchIfPresent: map[string][]string{
+					"qualified": []string{"true"},
+				},
+			},
+		},
+		{
+			desc:          "annotations, match if present: multiple options",
+			componentName: "ann",
+			expOut:        "1.2.0",
+			opts: &searchOpts{
+				matchIfPresent: map[string][]string{
+					"qualified": []string{"true", "zork"},
+				},
+			},
+		},
+		{
+			desc:          "annotations, match if present: exclude latest",
+			componentName: "ann",
+			expOut:        "1.1.0",
+			opts: &searchOpts{
+				matchIfPresent: map[string][]string{
+					"feature": []string{"biff", "zed"},
+				},
+			},
+		},
+		// errors
+		{
+			desc:          "annotations, exclude all",
+			componentName: "ann",
+			opts: &searchOpts{
+				exclude: map[string][]string{
+					"cool-component": []string{"true"},
+				},
+			},
+			expErrSubstr: "no latest version",
+		},
+		{
+			desc:          "annotations, non-existent annotation",
+			componentName: "ann",
+			opts: &searchOpts{
+				match: map[string][]string{
+					"dorp": []string{"true"},
+				},
+			},
+			expErrSubstr: "no latest version",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			vers, ok := sorted[tc.componentName]
+			if !ok {
+				t.Fatalf("no component found for %q", tc.componentName)
+			}
+			latest, err := vers.latest(tc.opts)
+			if cerr := testutil.CheckErrorCases(err, tc.expErrSubstr); cerr != nil {
+				t.Fatal(cerr)
+			}
+			if err != nil {
+				return
+			}
+			if got := latest.version.String(); got != tc.expOut {
+				t.Errorf("for component %q, got latest version %q but expected %q", tc.componentName, got, tc.expOut)
+			}
+		})
+	}
+}
+
+func TestPrevious(t *testing.T) {
+	testCases := []struct {
+		desc          string
+		comps         []string
+		componentName string
+		version       string
+		opts          *searchOpts
+
+		expOut       string
+		expErrSubstr string
+	}{
+		{
+			desc:          "strictly greater",
+			componentName: "foo",
+			version:       "3.0.0",
+			expOut:        "2.4.4",
+		},
+		{
+			desc:          "equiv version",
+			componentName: "foo",
+			version:       "2.4.4",
+			expOut:        "2.3.4",
+		},
+		{
+			desc:          "middle version",
+			componentName: "foo",
+			version:       "1.0.3",
+			expOut:        "1.0.2",
+		},
+		{
+			desc:          "bottom version",
+			componentName: "foo",
+			version:       "1.0.2",
+			expOut:        "1.0.1",
+		},
+		{
+			desc:          "single version, previous",
+			componentName: "boo",
+			version:       "3.0.2",
+			expOut:        "1.0.2",
+		},
+		{
+			desc:          "version suffix",
+			comps:         versionSuffix,
+			componentName: "foo",
+			version:       "2.4.4",
+			expOut:        "2.3.4-gke.12",
+		},
+		{
+			desc:          "version suffix, previous suffix",
+			comps:         versionSuffix,
+			componentName: "foo",
+			version:       "2.3.4-gke.12",
+			expOut:        "2.3.4-gke.2",
+		},
+		{
+			desc:          "version suffix, previous suffix, v2",
+			comps:         versionSuffix,
+			componentName: "foo",
+			version:       "2.3.4-gke.1",
+			expOut:        "2.3.4-gke.0",
+		},
+		{
+			desc:          "version suffix, previous suffix, v2",
+			comps:         versionSuffix,
+			componentName: "foo",
+			version:       "2.3.4-gke.0",
+			expOut:        "2.3.3-gke.0",
+		},
+
+		// error cases
+		{
+			desc:          "error: no bottom version",
+			componentName: "foo",
+			version:       "1.0.1",
+			expErrSubstr:  "no previous version",
+		},
+		{
+			desc:          "error: non-existent version",
+			componentName: "foo",
+			version:       "0.2.1",
+			expErrSubstr:  "no previous version",
+		},
+		{
+			desc:          "error: single version, equal",
+			componentName: "boo",
+			version:       "1.0.2",
+			expErrSubstr:  "no previous version",
+		},
+		{
+			desc:          "error: single version, before",
+			componentName: "boo",
+			version:       "0.0.2",
+			expErrSubstr:  "no previous version",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			raw := tc.comps
+			if len(raw) == 0 {
+				raw = defaultCollateComponents
+			}
+
+			comps, err := makeComps(raw)
+			if err != nil {
+				t.Fatal(err)
+			}
+			sorted, _, err := sortedMapFromComponents(comps)
+			if err != nil {
+				t.Fatal(err)
+			}
+			vers, ok := sorted[tc.componentName]
+			if !ok {
+				t.Fatalf("no component found for %q", tc.componentName)
+			}
+			ver, err := semver.Parse(tc.version)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			previous, err := vers.previous(ver, tc.opts)
+			cerr := testutil.CheckErrorCases(err, tc.expErrSubstr)
+			if cerr != nil {
+				t.Fatal(cerr)
+			}
+			if err != nil {
+				return
+			}
+			if got := previous.version.String(); got != tc.expOut {
+				t.Errorf("for component %q and version %q, got previous version %q but expected %q", tc.version, tc.componentName, got, tc.expOut)
+			}
+		})
+	}
+}
+
+func makeComps(cs []string) ([]*bundle.Component, error) {
+	var out []*bundle.Component
+	for _, c := range cs {
+		c, err := converter.FromYAMLString(c).ToComponent()
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, c)
+	}
+	return out, nil
+}

--- a/pkg/deps/latest.go
+++ b/pkg/deps/latest.go
@@ -212,9 +212,6 @@ func (r *graphBuilder) visitNode(curNode *node) ([]*node, error) {
 func processPicked(dep *requestedDep, curNode, picked *node) bool {
 	if picked.meta.version.GTE(dep.version) {
 		// It works!
-		if dep.version.GT(picked.minSatisfyingVersion) {
-			picked.minSatisfyingVersion = dep.version
-		}
 		return true
 	}
 	// It doesn't work. Indicate to the caller that a downgrade needs to be performed.

--- a/pkg/deps/latest.go
+++ b/pkg/deps/latest.go
@@ -1,0 +1,244 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deps
+
+import (
+	"fmt"
+
+	bundle "github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/apis/bundle/v1alpha1"
+	"github.com/blang/semver"
+)
+
+// rootNodeName is the name of the root noode. we use @ in the rootNode key
+// since @ is not valid chararcter in a componentName.
+const rootNodeName = "@root"
+
+// node is a dependency node, which corresponds to a component at a specific
+// version. Only one version of a component must exist in the graph.
+type node struct {
+	// children are nodes that this node depends on.
+	children []*node
+
+	meta *depMeta
+
+	// Maximum of the min requirements placed on this node.
+	maxOfMinReq semver.Version
+
+	// fixed determines whether this is fixed, meaning it cannot be downgraded.
+	// In other words, this is one of the components initially passed-in.
+	fixed bool
+}
+
+// String formats the data for the current node.
+func (n *node) String() string {
+	return fmt.Sprintf("{meta:%v, fixed:%t, maxOfMinReq:%v}", n.meta, n.fixed, n.maxOfMinReq)
+}
+
+func (r *Resolver) findLatest(exact, latest []*depMeta, opts *searchOpts) ([]bundle.ComponentReference, error) {
+	root := &node{}
+	toVisit := []*node{}
+	inQueue := make(map[string]bool)
+
+	initAdd := func(m *depMeta, isExact bool) {
+		n := &node{
+			meta:  m,
+			fixed: isExact,
+		}
+		root.children = append(root.children, n)
+		toVisit = append(toVisit, n)
+		inQueue[n.meta.componentName] = true
+	}
+
+	for _, m := range exact {
+		initAdd(m, true)
+	}
+	for _, m := range latest {
+		initAdd(m, false)
+	}
+
+	graphBuilder := &graphBuilder{
+		searchOpts: opts,
+		picked: map[string]*node{
+			rootNodeName: root,
+		},
+		componentVersions: r.componentVersions,
+		metaLookup:        r.metaLookup,
+	}
+
+	// Do a reverse postorder traversal of all the nodes.
+	for len(toVisit) > 0 {
+		var curNode *node
+		curNode, toVisit = shiftNode(toVisit)
+		delete(inQueue, curNode.meta.componentName)
+
+		children, err := graphBuilder.visitNode(curNode)
+		if err != nil {
+			return nil, err
+		}
+		for _, c := range children {
+			_, alreadyPicked := graphBuilder.picked[c.meta.componentName]
+			_, alreadyInQueue := inQueue[c.meta.componentName]
+			if !alreadyPicked && !alreadyInQueue {
+				toVisit = append(toVisit, c)
+			}
+		}
+		graphBuilder.picked[curNode.meta.componentName] = curNode
+	}
+
+	var refs []bundle.ComponentReference
+	for name, p := range graphBuilder.picked {
+		if name != rootNodeName {
+			refs = append(refs, p.meta.ref())
+		}
+	}
+	return refs, nil
+}
+
+// graphBuilder constructs a possibly cyclic dependency graph.
+type graphBuilder struct {
+	picked            map[string]*node
+	componentVersions map[string]*sortedVersions
+	metaLookup        map[bundle.ComponentReference]*depMeta
+	searchOpts        *searchOpts
+}
+
+func shiftNode(ns []*node) (*node, []*node) {
+	return ns[0], ns[1:]
+}
+
+// visitNode constructs the latest graph for a single node. It returns the
+// nodes that need to be visited next or an error if things didn't work out.
+func (r *graphBuilder) visitNode(curNode *node) ([]*node, error) {
+	for success := false; !success; {
+		// We'll assume that adding the deps went swimmingly.
+		success = true
+
+		for _, dep := range curNode.meta.reqDeps {
+			picked, alreadyPicked := r.picked[dep.componentName]
+
+			var newChild *node
+			if alreadyPicked {
+				// We already picked a component with the same component name. Check to
+				// make sure the version works with this component's dependency
+				// requirements
+				successfulPick, err := r.processPicked(dep, curNode, picked)
+				if err != nil {
+					return nil, err
+				}
+				if !successfulPick {
+					success = false
+					break
+				}
+				newChild = picked
+			} else {
+				// Do selection for the first time. We'll pick the latest component
+				// version of the component that satisfies the requirements.
+				latest, err := r.pickLatest(dep, curNode)
+				if err != nil {
+					return nil, err
+				}
+				if latest == nil {
+					success = false
+					break
+				}
+				newChild = latest
+			}
+			if !newChild.meta.visibleTo(curNode.meta) {
+				return nil, fmt.Errorf("component %v is not visible to component %v", newChild.meta, curNode.meta)
+			}
+			curNode.children = append(curNode.children, newChild)
+		}
+
+		if !success {
+			err := r.tryDowngrade(curNode)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+	return curNode.children, nil
+}
+
+// processPicked checks to make sure an already picked component works with the
+// existing constraints
+func (r *graphBuilder) processPicked(dep *requestedDep, curNode, picked *node) (bool, error) {
+	if picked.meta.version.GTE(dep.version) {
+		// It works!
+		return true, nil
+	}
+	if dep.version.GT(picked.maxOfMinReq) {
+		picked.maxOfMinReq = dep.version
+	}
+	// It doesn't work. Indicate to the caller that a downgrade needs to be performed.
+	return false, nil
+}
+
+// pickLatest picks the latest component for a given dependency requirement.
+func (r *graphBuilder) pickLatest(dep *requestedDep, curNode *node) (*node, error) {
+	sorted, ok := r.componentVersions[dep.componentName]
+	if !ok {
+		return nil, fmt.Errorf("could not find sorted component versions for component name %q", dep.componentName)
+	}
+	latest, err := sorted.latest(r.searchOpts)
+	if err != nil {
+		return nil, err
+	}
+	if latest.version.LT(dep.version) {
+		// This is a special error case: the latest version version of the dep
+		// doesn't work with the curNode
+		//
+		// If the latest version of the dependency is less than the requested
+		// version, our only option is to try to downgrade the parent node. We pass
+		// back nil to indicate as such.
+		return nil, nil
+	}
+	newChild := &node{
+		meta:        latest,
+		maxOfMinReq: dep.version,
+	}
+	return newChild, nil
+}
+
+// tryDowngrade tries to downgrade the current node version, in-place.
+//
+// This is done in the case where there was some, possibly recoverable
+// incomptibility. Because we always select the latest version of dependencies,
+// we don't have the option to upgrade the picked version. Instead, we can try
+// to downgrade current node and start the dependency process over for the
+// current node.
+func (r *graphBuilder) tryDowngrade(curNode *node) error {
+	if curNode.fixed {
+		// The current node is fixed because it was one of the components
+		// originally passed in. We're stuck.
+		return fmt.Errorf("attempting to downgrade component %v, but component was fixed (explicitly specified as one of the initial components)", curNode.meta.ref())
+	}
+	sorted, ok := r.componentVersions[curNode.meta.componentName]
+	if !ok {
+		return fmt.Errorf("could not find component versions for component name %q", curNode.meta.componentName)
+	}
+	previous, err := sorted.previous(curNode.meta.version, r.searchOpts)
+	if err != nil {
+		return fmt.Errorf("while trying to downgrade component %v, got error: %v", curNode.meta, err)
+	}
+	if previous.version.LT(curNode.maxOfMinReq) {
+		return fmt.Errorf("while trying to downgrade component %v, found incompatibility; previous version %v is less than the min version %v required by other components",
+			curNode.meta, previous, curNode.maxOfMinReq)
+	}
+
+	// Clear out the children and try again.
+	curNode.children = nil
+	curNode.meta = previous
+	return nil
+}

--- a/pkg/deps/matcher.go
+++ b/pkg/deps/matcher.go
@@ -1,0 +1,46 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deps
+
+import (
+	bundle "github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/apis/bundle/v1alpha1"
+)
+
+// MatchProcessor is a function that's called on every component during the
+// creation of the resolver.
+type MatchProcessor func(c *bundle.Component) (MatchMetadata, error)
+
+// NoOpMatchProcessor doesn't do any processing
+func NoOpMatchProcessor(c *bundle.Component) (MatchMetadata, error) {
+	return nil, nil
+}
+
+// MatchMetadata is optional metadata stored on the node to be used for matching.
+type MatchMetadata interface{}
+
+// Matcher is a function that performs some additional *unconditional* matching
+// on a node. True means that the component should be used; false means it
+// shouldn't.
+//
+// In other words, the matching that is applied should be consistent
+// across components during the matching phase. If the matching is conditional,
+// which is to say relies on some context of the parents or children, then it
+// will cause errors in dependency resolution.
+type Matcher func(ref bundle.ComponentReference, m MatchMetadata) bool
+
+// NoOpMatcher doesn't do any matching; it returns true (use component) for all components.
+func NoOpMatcher(ref bundle.ComponentReference, m MatchMetadata) bool {
+	return true
+}

--- a/pkg/deps/meta.go
+++ b/pkg/deps/meta.go
@@ -1,0 +1,177 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deps
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	bundle "github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/apis/bundle/v1alpha1"
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/converter"
+	"github.com/blang/semver"
+)
+
+// A single requested dependency.
+type requestedDep struct {
+	componentName string
+	version       semver.Version
+}
+
+// String formats the requestedDep as a string
+func (r *requestedDep) String() string {
+	return fmt.Sprintf("{%s, %s}", r.componentName, r.version)
+}
+
+// depMeta contains dependency metadata about a single component.
+type depMeta struct {
+	componentName string
+	version       semver.Version
+	reqDeps       []*requestedDep
+	visibility    map[string]bool
+	annotations   map[string]string
+}
+
+// String prints a stringified version of the depMeta object.
+func (m *depMeta) String() string {
+	baseStr := fmt.Sprintf("{reference:{%s, %s}", m.componentName, m.version.String())
+	if len(m.reqDeps) > 0 {
+		baseStr = baseStr + fmt.Sprintf(" requirements:%v", m.reqDeps)
+	}
+	if len(m.visibility) > 0 {
+		baseStr = baseStr + fmt.Sprintf(" visibility:%v", m.visibility)
+	}
+	baseStr += "}"
+	return baseStr
+}
+
+// versionStr returns the version string.
+func (m *depMeta) versionStr() string { return m.version.String() }
+
+// ref makes a component reference.
+func (m *depMeta) ref() bundle.ComponentReference {
+	return bundle.ComponentReference{m.componentName, m.version.String()}
+}
+
+// visibleTo returns whether this component is visible to another component.
+func (m *depMeta) visibleTo(other *depMeta) bool {
+	if len(m.visibility) == 0 || m.visibility["@private"] {
+		return false
+	}
+	if m.visibility["@public"] {
+		return true
+	}
+	return m.visibility[other.componentName]
+}
+
+// metaFromComponent creates the depMeta object from a component.
+func metaFromComponent(c *bundle.Component) (*depMeta, error) {
+	if c.Spec.ComponentName == "" || c.Spec.Version == "" {
+		return nil, fmt.Errorf("both componentName and version must be defined for each component, but found componentName:%s, version:%s", c.Spec.ComponentName, c.Spec.Version)
+	}
+
+	m := &depMeta{
+		componentName: c.Spec.ComponentName,
+		visibility:    make(map[string]bool),
+		annotations:   make(map[string]string),
+	}
+
+	ver, err := semver.Parse(c.Spec.Version)
+	if err != nil {
+		return nil, fmt.Errorf("while parsing version %q as semver in component %v: %v", c.Spec.Version, c.ComponentReference(), err)
+	}
+	m.version = ver
+
+	if len(c.ObjectMeta.Annotations) > 0 {
+		for k, v := range c.ObjectMeta.Annotations {
+			m.annotations[k] = v
+		}
+	}
+
+	var req *bundle.Requirements
+	for _, o := range c.Spec.Objects {
+		if o.GetKind() != "Requirements" {
+			continue
+		}
+		if o.GetAPIVersion() != "" && !strings.Contains(o.GetAPIVersion(), "bundle.gke.io") {
+			continue
+		}
+		inreq := &bundle.Requirements{}
+		err := converter.FromUnstructured(o).ToObject(inreq)
+		if err != nil {
+			return nil, fmt.Errorf("for component %v: %v", m.ref(), err)
+		}
+		if req != nil {
+			return nil, fmt.Errorf("duplicate requirements object found for component %v", m.ref())
+		}
+		req = inreq
+	}
+
+	if req != nil {
+		for _, vis := range req.Visibility {
+			if vis != "" {
+				m.visibility[vis] = true
+			}
+		}
+	}
+
+	reqDeps, err := flattenRequired(m.ref(), req)
+	if err != nil {
+		return nil, err
+	}
+	m.reqDeps = reqDeps
+	return m, nil
+}
+
+var (
+	// numPattern is a regexp string for numbers without leading zeros.
+	numPattern = `([1-9]\d*|0)`
+
+	// semvers of the form X.Y
+	majorMinorPattern = regexp.MustCompile(fmt.Sprintf(`^%s\.%s$`, numPattern, numPattern))
+)
+
+// flattenRequired takes a requirements object from a component and flattens
+// into a list of requested deps.
+func flattenRequired(ref bundle.ComponentReference, req *bundle.Requirements) ([]*requestedDep, error) {
+	if req == nil {
+		// This is a valid/normal case -- no dependencies specified.
+		return nil, nil
+	}
+
+	var deps []*requestedDep
+	for _, d := range req.Require {
+		if d.ComponentName == "" {
+			return nil, fmt.Errorf("for component %v, component name was not defined for require field %v in requirements object %v", ref, d, req)
+		}
+		verstr := d.Version
+		if verstr == "" {
+			verstr = "0.0.0"
+		}
+		if majorMinorPattern.MatchString(verstr) {
+			verstr = verstr + ".0"
+		}
+		ver, err := semver.Parse(verstr)
+		if err != nil {
+			return nil, fmt.Errorf("for component %v, error while parsing requirement version %q as semver for required component %q: %v", ref, verstr, d.ComponentName, err)
+		}
+
+		deps = append(deps, &requestedDep{
+			componentName: d.ComponentName,
+			version:       ver,
+		})
+	}
+	return deps, nil
+}

--- a/pkg/deps/meta_test.go
+++ b/pkg/deps/meta_test.go
@@ -1,0 +1,203 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deps
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/converter"
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/testutil"
+)
+
+func TestConvertMeta(t *testing.T) {
+	testCases := []struct {
+		desc      string
+		component string
+
+		expName       string
+		expVersion    string
+		expVisibility []string
+		expAnnot      map[string]string
+		expErrSubstr  string
+		expRequire    bool
+	}{
+		{
+			desc: "basic parse",
+			component: `
+kind: Component
+spec:
+  componentName: foo
+  version: 0.2.0
+`,
+			expName:    "foo",
+			expVersion: "0.2.0",
+		},
+		{
+			desc: "requirements",
+			component: `
+kind: Component
+spec:
+  componentName: foo
+  version: 0.2.0
+  objects:
+  - apiVersion: bundle.gke.io/v1alpha1
+    kind: Requirements
+    require:
+    - componentName: foo
+    - componentName: bar
+      version: 0.2.6
+`,
+			expName:    "foo",
+			expVersion: "0.2.0",
+			expRequire: true,
+		},
+		{
+			desc: "requirements + visibility",
+			component: `
+kind: Component
+spec:
+  componentName: foo
+  version: 0.2.0
+  objects:
+  - apiVersion: bundle.gke.io/v1alpha1
+    kind: Requirements
+    require:
+    - componentName: foo
+    - componentName: bar
+      version: 0.2.6
+    visibility:
+    - biff
+    - bam
+`,
+			expName:       "foo",
+			expVersion:    "0.2.0",
+			expRequire:    true,
+			expVisibility: []string{"biff", "bam"},
+		},
+		{
+			desc: "annotations",
+			component: `
+kind: Component
+metadata:
+  annotations:
+    foo: bar
+    biff: bazz
+spec:
+  componentName: foo
+  version: 0.2.0
+`,
+			expName:    "foo",
+			expVersion: "0.2.0",
+			expAnnot: map[string]string{
+				"foo":  "bar",
+				"biff": "bazz",
+			},
+		},
+
+		// errors
+		{
+			desc: "no componentName",
+			component: `
+kind: Component
+spec:
+  version: 0.2.0
+`,
+			expErrSubstr: "both componentName and version",
+		},
+		{
+			desc: "no version",
+			component: `
+kind: Component
+spec:
+  componentName: foo
+`,
+			expErrSubstr: "both componentName and version",
+		},
+		{
+			desc: "bad version",
+			component: `
+kind: Component
+spec:
+  componentName: foo
+  version: 0.2.0.4
+`,
+			expErrSubstr: "while parsing version",
+		},
+		{
+			desc: "duplicate requirements",
+			component: `
+kind: Component
+spec:
+  componentName: foo
+  version: 0.2.0
+  objects:
+  - apiVersion: bundle.gke.io/v1alpha1
+    kind: Requirements
+    require:
+    - componentName: foo
+    - componentName: bar
+      version: 0.2.6
+  - apiVersion: bundle.gke.io/v1alpha1
+    kind: Requirements
+    require:
+    - componentName: biff
+    - componentName: bam
+      version: 0.2.6
+`,
+			expErrSubstr: "duplicate requirements object",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			comp, err := converter.FromYAMLString(tc.component).ToComponent()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			m, err := metaFromComponent(comp)
+			expErr := testutil.CheckErrorCases(err, tc.expErrSubstr)
+			if expErr != nil {
+				t.Fatal(expErr)
+			}
+			if err != nil {
+				return
+			}
+
+			if gotName := m.componentName; tc.expName != gotName {
+				t.Errorf("got componentName %q but wanted %q", gotName, tc.expVersion)
+			}
+			if gotVer := m.versionStr(); tc.expVersion != gotVer {
+				t.Errorf("got version %q but wanted %q", gotVer, tc.expVersion)
+			}
+			if tc.expRequire && (m.reqDeps == nil || len(m.reqDeps) == 0) {
+				t.Error("got no requirements object but expected one")
+			} else if !tc.expRequire && (m.reqDeps != nil || len(m.reqDeps) > 0) {
+				t.Errorf("got requirements object %+v but did not expected one", m.reqDeps)
+			}
+			expVisMap := make(map[string]bool)
+			for _, st := range tc.expVisibility {
+				expVisMap[st] = true
+			}
+			if !reflect.DeepEqual(expVisMap, m.visibility) {
+				t.Errorf("got visibility %v but expected %v", m.visibility, expVisMap)
+			}
+			if len(tc.expAnnot) > 0 && !reflect.DeepEqual(tc.expAnnot, m.annotations) {
+				t.Errorf("got annotations %v but expected %v", m.annotations, expVisMap)
+			}
+		})
+	}
+}

--- a/pkg/deps/meta_test.go
+++ b/pkg/deps/meta_test.go
@@ -30,7 +30,7 @@ func TestConvertMeta(t *testing.T) {
 		expName       string
 		expVersion    string
 		expVisibility []string
-		expAnnot      map[string]string
+		expMatchMeta  MatchMetadata
 		expErrSubstr  string
 		expRequire    bool
 	}{
@@ -101,9 +101,11 @@ spec:
 `,
 			expName:    "foo",
 			expVersion: "0.2.0",
-			expAnnot: map[string]string{
-				"foo":  "bar",
-				"biff": "bazz",
+			expMatchMeta: &AnnotationMetadata{
+				Annotations: map[string]string{
+					"foo":  "bar",
+					"biff": "bazz",
+				},
 			},
 		},
 
@@ -168,7 +170,7 @@ spec:
 				t.Fatal(err)
 			}
 
-			m, err := metaFromComponent(comp)
+			m, err := metaFromComponent(comp, AnnotationProcessor)
 			expErr := testutil.CheckErrorCases(err, tc.expErrSubstr)
 			if expErr != nil {
 				t.Fatal(expErr)
@@ -195,8 +197,8 @@ spec:
 			if !reflect.DeepEqual(expVisMap, m.visibility) {
 				t.Errorf("got visibility %v but expected %v", m.visibility, expVisMap)
 			}
-			if len(tc.expAnnot) > 0 && !reflect.DeepEqual(tc.expAnnot, m.annotations) {
-				t.Errorf("got annotations %v but expected %v", m.annotations, expVisMap)
+			if tc.expMatchMeta != nil && !reflect.DeepEqual(tc.expMatchMeta, m.matchMeta) {
+				t.Errorf("got matchMeta %v but expected %v", m.matchMeta, tc.expMatchMeta)
 			}
 		})
 	}

--- a/pkg/deps/resolve.go
+++ b/pkg/deps/resolve.go
@@ -1,0 +1,167 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package deps resolves component dependencies based on a collection of
+// components and some input-requirements
+package deps
+
+import (
+	"fmt"
+
+	bundle "github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/apis/bundle/v1alpha1"
+)
+
+// Resolver is a dependency resolver.
+type Resolver struct {
+	componentVersions map[string]*sortedVersions
+	metaLookup        map[bundle.ComponentReference]*depMeta
+	componentLookup   map[bundle.ComponentReference]*bundle.Component
+}
+
+// NewResolver takes in a list of components that make up the universe.
+func NewResolver(components []*bundle.Component) (*Resolver, error) {
+	svm, lup, err := sortedMapFromComponents(components)
+	if err != nil {
+		return nil, err
+	}
+	componentLookup := make(map[bundle.ComponentReference]*bundle.Component)
+	for _, c := range components {
+		componentLookup[c.ComponentReference()] = c
+	}
+
+	return &Resolver{
+		componentVersions: svm,
+		metaLookup:        lup,
+		componentLookup:   componentLookup,
+	}, nil
+}
+
+// Component retrieves a component (which is copied for safety), returning nil
+// if isn't known by the resolver.
+func (r *Resolver) Component(ref bundle.ComponentReference) *bundle.Component {
+	c := r.componentLookup[ref]
+	if c == nil {
+		return nil
+	}
+	return c.DeepCopy()
+}
+
+// HasComponent indicates whether a component is known by the resolver.
+func (r *Resolver) HasComponent(ref bundle.ComponentReference) bool {
+	return r.componentLookup[ref] != nil
+}
+
+// Add adds components to the resolver, returning a new resolver or
+// an error if it fails. If one of the new components provided has the same
+// name/version, it overwrites the existing component map.
+func (r *Resolver) Add(newComps []*bundle.Component) (*Resolver, error) {
+	m := make(map[bundle.ComponentReference]*bundle.Component)
+	for k, c := range r.componentLookup {
+		m[k] = c
+	}
+	for _, c := range newComps {
+		m[c.ComponentReference()] = c
+	}
+	var cs []*bundle.Component
+	for _, c := range m {
+		cs = append(cs, c)
+	}
+	return NewResolver(cs)
+}
+
+// ComponentVersions gets the versions for a particular component
+func (r *Resolver) ComponentVersions(comp string) ([]bundle.ComponentReference, error) {
+	cv, ok := r.componentVersions[comp]
+	if !ok {
+		return nil, fmt.Errorf("unknown component %q", comp)
+	}
+	var versions []bundle.ComponentReference
+	for _, ver := range cv.versions {
+		versions = append(versions, bundle.ComponentReference{
+			ComponentName: cv.componentName,
+			Version:       ver.version.String(),
+		})
+	}
+	return versions, nil
+}
+
+// ResolveOptions are options for resolving dependencies
+type ResolveOptions struct {
+	// Match are component annotations that must to be present. This is useful
+	// for matching positive characteristics of a component (example: this
+	// component passed qualification). Only one of the list of values need
+	// be present.
+	//
+	// In other words, this is a logical AND operation of the passed in Annotation and
+	// the component Annotation.
+	Match map[string][]string
+
+	// MatchIfPresent are component annotations that are analyzed if they are
+	// present on the component. This is useful for synchronizing values between
+	// the universe of components and the caller.
+	MatchIfPresent map[string][]string
+
+	// Exclude are component annotations that must not be present.  This is
+	// useful for matching positive characteristics of a component (this
+	// component passed qualification). If any of the the list of values match,
+	// the component is excluded.
+	//
+	// In other words, this is a logical NAND operation of the passed in
+	// Annotation and the component Annotation.
+	Exclude map[string][]string
+}
+
+// ResolveLatest resolves dependencies for several components, returning
+// the components references that correspond to that version selection.
+//
+// These components must exist within the Resolver's set of components. If a
+// version is not specified for a component reference, the latest version is
+// used.
+func (r *Resolver) ResolveLatest(refs []bundle.ComponentReference, opts *ResolveOptions) ([]bundle.ComponentReference, error) {
+	var exact []*depMeta
+	var latest []*depMeta
+	sopts := &searchOpts{}
+	if opts != nil {
+		sopts.match = opts.Match
+		sopts.exclude = opts.Exclude
+		sopts.matchIfPresent = opts.MatchIfPresent
+	}
+	for _, ref := range refs {
+		cv, ok := r.componentVersions[ref.ComponentName]
+		if !ok {
+			return nil, fmt.Errorf("unknown component %q", ref.ComponentName)
+		}
+		if cv == nil || len(cv.versions) == 0 {
+			return nil, fmt.Errorf("no versions found for component %q", ref.ComponentName)
+		}
+		if ref.Version == "" {
+			ver, err := cv.latest(sopts)
+			if err != nil {
+				return nil, err
+			}
+			latest = append(latest, ver)
+		} else {
+			m, ok := r.metaLookup[ref]
+			if !ok {
+				versions, err := r.ComponentVersions(ref.ComponentName)
+				if err != nil {
+					return nil, err
+				}
+				return nil, fmt.Errorf("unknown component %v; known versions are %v", ref, versions)
+			}
+			exact = append(exact, m)
+		}
+	}
+	return r.findLatest(exact, latest, sopts)
+}

--- a/pkg/deps/resolve_test.go
+++ b/pkg/deps/resolve_test.go
@@ -609,9 +609,11 @@ spec:
 				{ComponentName: "kubernetes"},
 			},
 			opts: &ResolveOptions{
-				Match: map[string][]string{
-					"cool-component": []string{"true"},
-				},
+				Matcher: AnnotationMatcher(&AnnotationCriteria{
+					Match: map[string][]string{
+						"cool-component": []string{"true"},
+					},
+				}),
 			},
 			expComps: []bundle.ComponentReference{
 				{ComponentName: "kubernetes", Version: "1.11.0"},
@@ -625,10 +627,12 @@ spec:
 				{ComponentName: "kubernetes"},
 			},
 			opts: &ResolveOptions{
-				Match: map[string][]string{
-					"cool-component": []string{"true"},
-					"qualified":      []string{"true"},
-				},
+				Matcher: AnnotationMatcher(&AnnotationCriteria{
+					Match: map[string][]string{
+						"cool-component": []string{"true"},
+						"qualified":      []string{"true"},
+					},
+				}),
 			},
 			expComps: []bundle.ComponentReference{
 				{ComponentName: "kubernetes", Version: "1.11.0"},
@@ -642,13 +646,15 @@ spec:
 				{ComponentName: "kubernetes"},
 			},
 			opts: &ResolveOptions{
-				Match: map[string][]string{
-					"cool-component": []string{"true"},
-					"qualified":      []string{"true"},
-				},
-				Exclude: map[string][]string{
-					"bad-component": []string{"true"},
-				},
+				Matcher: AnnotationMatcher(&AnnotationCriteria{
+					Match: map[string][]string{
+						"cool-component": []string{"true"},
+						"qualified":      []string{"true"},
+					},
+					Exclude: map[string][]string{
+						"bad-component": []string{"true"},
+					},
+				}),
 			},
 			expComps: []bundle.ComponentReference{
 				{ComponentName: "kubernetes", Version: "1.11.0"},
@@ -747,11 +753,13 @@ spec:
 				{ComponentName: "kubernetes"},
 			},
 			opts: &ResolveOptions{
-				Match: map[string][]string{
-					"bad-component": []string{"true"},
-				},
+				Matcher: AnnotationMatcher(&AnnotationCriteria{
+					Match: map[string][]string{
+						"bad-component": []string{"true"},
+					},
+				}),
 			},
-			expErrSubstr: "no latest version matching criteria",
+			expErrSubstr: "no latest version",
 		},
 		{
 			desc:     "annotations: can't match any",
@@ -760,11 +768,13 @@ spec:
 				{ComponentName: "kubernetes"},
 			},
 			opts: &ResolveOptions{
-				Match: map[string][]string{
-					"zorp": []string{"true"},
-				},
+				Matcher: AnnotationMatcher(&AnnotationCriteria{
+					Match: map[string][]string{
+						"zorp": []string{"true"},
+					},
+				}),
 			},
-			expErrSubstr: "no latest version matching criteria",
+			expErrSubstr: "no latest version",
 		},
 	}
 
@@ -779,7 +789,7 @@ spec:
 				parsedComps = append(parsedComps, comp)
 			}
 
-			resolver, err := NewResolver(parsedComps)
+			resolver, err := NewResolver(parsedComps, AnnotationProcessor)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -789,7 +799,7 @@ spec:
 				expMap[ec.ComponentName] = ec.Version
 			}
 
-			got, err := resolver.ResolveLatest(tc.comps, tc.opts)
+			got, err := resolver.Resolve(tc.comps, tc.opts)
 			if cerr := testutil.CheckErrorCases(err, tc.expErrSubstr); cerr != nil {
 				t.Fatal(cerr)
 			}

--- a/pkg/deps/resolve_test.go
+++ b/pkg/deps/resolve_test.go
@@ -1,0 +1,810 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deps
+
+import (
+	"reflect"
+	"testing"
+
+	bundle "github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/apis/bundle/v1alpha1"
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/converter"
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/testutil"
+)
+
+var twoLayerCyclic = []string{
+	`
+kind: Component
+spec:
+  componentName: foo
+  version: 0.3.0
+  objects:
+  - kind: Requirements
+    visibility:
+    - '@public'
+    require:
+    - componentName: kubernetes
+      version: 1.1.0`,
+	`
+kind: Component
+spec:
+  componentName: foo
+  version: 0.4.0
+  objects:
+  - kind: Requirements
+    visibility:
+    - '@public'
+    require:
+    - componentName: kubernetes
+      version: 1.3.0`,
+	`
+kind: Component
+spec:
+  componentName: kubernetes
+  version: 1.2.0
+  objects:
+  - kind: Requirements
+    visibility:
+    - '@public'
+    require:
+    - componentName: foo`,
+}
+
+var threeLayerCyclic = []string{
+	`
+kind: Component
+spec:
+  componentName: low
+  version: 2.3.0
+  objects:
+  - kind: Requirements
+    visibility:
+    - '@public'
+    require:
+    - componentName: high
+      version: 1.3.0`,
+	`
+kind: Component
+spec:
+  componentName: low
+  version: 2.2.0
+  objects:
+  - kind: Requirements
+    visibility:
+    - '@public'
+    require:
+    - componentName: high
+      version: 1.2.0`,
+	`
+kind: Component
+spec:
+  componentName: mid
+  version: 0.3.0
+  objects:
+  - kind: Requirements
+    visibility:
+    - '@public'
+    require:
+    - componentName: high
+      version: 1.1.0
+    - componentName: low`,
+	`
+kind: Component
+spec:
+  componentName: mid
+  version: 0.4.0
+  objects:
+  - kind: Requirements
+    visibility:
+    - '@public'
+    require:
+    - componentName: high
+      version: 1.3.0
+    - componentName: low`,
+	`
+kind: Component
+spec:
+  componentName: high
+  version: 1.2.0
+  objects:
+  - kind: Requirements
+    visibility:
+    - '@public'
+    require:
+    - componentName: mid`,
+}
+
+var diagonalDeps = []string{
+	`
+kind: Component
+spec:
+  componentName: low
+  version: 2.3.0
+  objects:
+  - kind: Requirements
+    visibility:
+    - '@public'
+    require:
+    - componentName: high
+      version: 1.2.0`,
+	`
+kind: Component
+spec:
+  componentName: low
+  version: 2.2.0
+  objects:
+  - kind: Requirements
+    visibility:
+    - '@public'`,
+	`
+kind: Component
+spec:
+  componentName: mid2
+  version: 2.3.0
+  objects:
+  - kind: Requirements
+    visibility:
+    - '@public'
+    require:
+    - componentName: low
+      version: 2.3.0`,
+	`
+kind: Component
+spec:
+  componentName: mid1
+  version: 1.2.0
+  objects:
+  - kind: Requirements
+    visibility:
+    - '@public'
+    require:
+    - componentName: low
+      version: 2.2.0`,
+	`
+kind: Component
+spec:
+  componentName: mid1
+  version: 1.3.0
+  objects:
+  - kind: Requirements
+    visibility:
+    - '@public'
+    require:
+    - componentName: low
+      version: 2.2.0`,
+	`
+kind: Component
+spec:
+  componentName: high
+  version: 1.2.0
+  objects:
+  - kind: Requirements
+    visibility:
+    - '@public'
+    require:
+    - componentName: mid1
+    - componentName: mid2`,
+	`
+kind: Component
+spec:
+  componentName: high
+  version: 1.1.0
+  objects:
+  - kind: Requirements
+    visibility:
+    - '@public'
+    require:
+    - componentName: mid1
+    - componentName: mid2`,
+}
+
+var apiVisibilityPattern = []string{
+	`
+kind: Component
+spec:
+  componentName: foo
+  version: 0.3.0
+  objects:
+  - kind: Requirements
+    require:
+    - componentName: foo-api
+    - componentName: kubernetes
+      version: 1.2
+    visibility:
+    - foo-api`,
+	`
+kind: Component
+spec:
+  componentName: bad-vis
+  version: 3.3.0
+  objects:
+  - kind: Requirements
+    visibility:
+    - '@public'
+    require:
+    - componentName: foo`,
+	`
+kind: Component
+spec:
+  componentName: foo-api
+  version: 1.1.0
+  objects:
+  - kind: Requirements
+    visibility:
+    - '@public'
+    require:
+    - componentName: foo
+      version: 0.3`,
+	`
+kind: Component
+spec:
+  componentName: kubernetes
+  version: 1.2.0
+  objects:
+  - kind: Requirements
+    visibility:
+    - '@public'`,
+}
+
+var annotationSet = []string{
+	`
+kind: Component
+metadata:
+  annotations:
+    cool-component: true
+    qualified: true
+spec:
+  componentName: kubernetes
+  version: 1.11.0
+  objects:
+  - kind: Requirements
+    visibility:
+    - '@public'
+    require:
+    - componentName: ann`,
+	`
+kind: Component
+metadata:
+  annotations:
+    cool-component: true
+    qualified: true
+spec:
+  componentName: ann
+  version: 1.0.0
+  objects:
+  - kind: Requirements
+    visibility:
+    - '@public'
+`,
+	`
+kind: Component
+metadata:
+  annotations:
+    cool-component: true
+    qualified: true
+    bad-component: true
+spec:
+  componentName: ann
+  version: 1.1.0
+  objects:
+  - kind: Requirements
+    visibility:
+    - '@public'
+`,
+	`
+kind: Component
+metadata:
+  annotations:
+    cool-component: true
+spec:
+  componentName: ann
+  version: 1.2.0
+  objects:
+  - kind: Requirements
+    visibility:
+    - '@public'
+`,
+}
+
+func TestResolveLatest(t *testing.T) {
+	testCases := []struct {
+		desc     string
+		universe []string
+		comps    []bundle.ComponentReference
+		opts     *ResolveOptions
+
+		expComps     []bundle.ComponentReference
+		expErrSubstr string
+	}{
+		{
+			desc: "one component: exact",
+			universe: []string{
+				`
+kind: Component
+spec:
+  componentName: foo
+  version: 0.2.0`,
+			},
+			comps: []bundle.ComponentReference{
+				{ComponentName: "foo", Version: "0.2.0"},
+			},
+			expComps: []bundle.ComponentReference{
+				{ComponentName: "foo", Version: "0.2.0"},
+			},
+		},
+
+		{
+			desc: "one component: latest",
+			universe: []string{
+				`
+kind: Component
+spec:
+  componentName: foo
+  version: 0.2.0`,
+			},
+			comps: []bundle.ComponentReference{
+				{ComponentName: "foo"},
+			},
+			expComps: []bundle.ComponentReference{
+				{ComponentName: "foo", Version: "0.2.0"},
+			},
+		},
+
+		{
+			desc: "two layer, latest",
+			universe: []string{
+				`
+kind: Component
+spec:
+  componentName: foo
+  version: 0.2.0
+  objects:
+  - kind: Requirements
+    visibility:
+    - '@public'`,
+				`
+kind: Component
+spec:
+  componentName: foo
+  version: 0.2.1
+  objects:
+  - kind: Requirements
+    visibility:
+    - '@public'`,
+				`
+kind: Component
+spec:
+  componentName: kubernetes
+  version: 1.2.0
+  objects:
+  - kind: Requirements
+    require:
+    - componentName: foo
+  `,
+			},
+			comps: []bundle.ComponentReference{
+				{ComponentName: "kubernetes"},
+			},
+			expComps: []bundle.ComponentReference{
+				{ComponentName: "foo", Version: "0.2.1"},
+				{ComponentName: "kubernetes", Version: "1.2.0"},
+			},
+		},
+
+		{
+			desc: "two layer, min requirement",
+			universe: []string{
+				`
+kind: Component
+spec:
+  componentName: foo
+  version: 0.2.0
+  objects:
+  - kind: Requirements
+    visibility:
+    - kubernetes`,
+				`
+kind: Component
+spec:
+  componentName: foo
+  version: 0.2.1
+  objects:
+  - kind: Requirements
+    visibility:
+    - kubernetes`,
+				`
+kind: Component
+spec:
+  componentName: kubernetes
+  version: 1.2.0
+  objects:
+  - kind: Requirements
+    require:
+    - componentName: foo
+      version: 0.2.1
+  `,
+			},
+			comps: []bundle.ComponentReference{
+				{ComponentName: "kubernetes"},
+			},
+			expComps: []bundle.ComponentReference{
+				{ComponentName: "foo", Version: "0.2.1"},
+				{ComponentName: "kubernetes", Version: "1.2.0"},
+			},
+		},
+		{
+			desc: "two layer, cyclic, simple",
+			universe: []string{`
+kind: Component
+spec:
+  componentName: foo
+  version: 0.2.1
+  objects:
+  - kind: Requirements
+    visibility:
+    - kubernetes
+    require:
+    - componentName: kubernetes
+      version: 0.2.1`,
+				`
+kind: Component
+spec:
+  componentName: kubernetes
+  version: 1.2.0
+  objects:
+  - kind: Requirements
+    visibility:
+    - foo
+    require:
+    - componentName: foo`},
+			comps: []bundle.ComponentReference{
+				{ComponentName: "kubernetes"},
+			},
+			expComps: []bundle.ComponentReference{
+				{ComponentName: "foo", Version: "0.2.1"},
+				{ComponentName: "kubernetes", Version: "1.2.0"},
+			},
+		},
+		{
+			desc:     "two layer, cyclic, downgrade",
+			universe: twoLayerCyclic,
+			comps: []bundle.ComponentReference{
+				{ComponentName: "kubernetes"},
+			},
+			expComps: []bundle.ComponentReference{
+				{ComponentName: "foo", Version: "0.3.0"},
+				{ComponentName: "kubernetes", Version: "1.2.0"},
+			},
+		},
+		{
+			desc:     "two layer, cyclic, two specified at top + downgrade",
+			universe: twoLayerCyclic,
+			comps: []bundle.ComponentReference{
+				{ComponentName: "kubernetes"},
+				{ComponentName: "foo"},
+			},
+			expComps: []bundle.ComponentReference{
+				{ComponentName: "foo", Version: "0.3.0"},
+				{ComponentName: "kubernetes", Version: "1.2.0"},
+			},
+		},
+		{
+			desc:     "two layer, reversed ordering",
+			universe: twoLayerCyclic,
+			comps: []bundle.ComponentReference{
+				{ComponentName: "foo"},
+			},
+			expComps: []bundle.ComponentReference{
+				{ComponentName: "foo", Version: "0.3.0"},
+				{ComponentName: "kubernetes", Version: "1.2.0"},
+			},
+		},
+		{
+			desc:     "two layer, reversed ordering",
+			universe: twoLayerCyclic,
+			comps: []bundle.ComponentReference{
+				{ComponentName: "foo"},
+			},
+			expComps: []bundle.ComponentReference{
+				{ComponentName: "foo", Version: "0.3.0"},
+				{ComponentName: "kubernetes", Version: "1.2.0"},
+			},
+		},
+		{
+			desc:     "three layer cyclic",
+			universe: threeLayerCyclic,
+			comps: []bundle.ComponentReference{
+				{ComponentName: "high"},
+			},
+			expComps: []bundle.ComponentReference{
+				{ComponentName: "high", Version: "1.2.0"},
+				{ComponentName: "mid", Version: "0.3.0"},
+				{ComponentName: "low", Version: "2.2.0"},
+			},
+		},
+		{
+			desc:     "three layer cyclic, reversed",
+			universe: threeLayerCyclic,
+			comps: []bundle.ComponentReference{
+				{ComponentName: "low"},
+			},
+			expComps: []bundle.ComponentReference{
+				{ComponentName: "high", Version: "1.2.0"},
+				{ComponentName: "mid", Version: "0.3.0"},
+				{ComponentName: "low", Version: "2.2.0"},
+			},
+		},
+		{
+			desc:     "api pattern",
+			universe: apiVisibilityPattern,
+			comps: []bundle.ComponentReference{
+				{ComponentName: "foo-api"},
+			},
+			expComps: []bundle.ComponentReference{
+				{ComponentName: "kubernetes", Version: "1.2.0"},
+				{ComponentName: "foo", Version: "0.3.0"},
+				{ComponentName: "foo-api", Version: "1.1.0"},
+			},
+		},
+		{
+			desc:     "diagonal dependencies",
+			universe: diagonalDeps,
+			comps: []bundle.ComponentReference{
+				{ComponentName: "high"},
+			},
+			expComps: []bundle.ComponentReference{
+				{ComponentName: "high", Version: "1.2.0"},
+				{ComponentName: "mid1", Version: "1.3.0"},
+				{ComponentName: "mid2", Version: "2.3.0"},
+				{ComponentName: "low", Version: "2.3.0"},
+			},
+		},
+		{
+			desc:     "re-pick diagonal dependencies",
+			universe: diagonalDeps,
+			comps: []bundle.ComponentReference{
+				{ComponentName: "high", Version: "1.2.0"},
+				{ComponentName: "mid1", Version: "1.3.0"},
+				{ComponentName: "mid2", Version: "2.3.0"},
+				{ComponentName: "low", Version: "2.3.0"},
+			},
+			expComps: []bundle.ComponentReference{
+				{ComponentName: "high", Version: "1.2.0"},
+				{ComponentName: "mid1", Version: "1.3.0"},
+				{ComponentName: "mid2", Version: "2.3.0"},
+				{ComponentName: "low", Version: "2.3.0"},
+			},
+		},
+		{
+			desc:     "re-pick diagonal dependencies + manual downgrade",
+			universe: diagonalDeps,
+			comps: []bundle.ComponentReference{
+				{ComponentName: "high", Version: "1.2.0"},
+				{ComponentName: "mid1", Version: "1.2.0"},
+				{ComponentName: "mid2", Version: "2.3.0"},
+				{ComponentName: "low", Version: "2.3.0"},
+			},
+			expComps: []bundle.ComponentReference{
+				{ComponentName: "high", Version: "1.2.0"},
+				{ComponentName: "mid1", Version: "1.2.0"},
+				{ComponentName: "mid2", Version: "2.3.0"},
+				{ComponentName: "low", Version: "2.3.0"},
+			},
+		},
+		{
+			desc:     "annotations: match all",
+			universe: annotationSet,
+			comps: []bundle.ComponentReference{
+				{ComponentName: "kubernetes"},
+			},
+			opts: &ResolveOptions{
+				Match: map[string][]string{
+					"cool-component": []string{"true"},
+				},
+			},
+			expComps: []bundle.ComponentReference{
+				{ComponentName: "kubernetes", Version: "1.11.0"},
+				{ComponentName: "ann", Version: "1.2.0"},
+			},
+		},
+		{
+			desc:     "annotations: match qualified",
+			universe: annotationSet,
+			comps: []bundle.ComponentReference{
+				{ComponentName: "kubernetes"},
+			},
+			opts: &ResolveOptions{
+				Match: map[string][]string{
+					"cool-component": []string{"true"},
+					"qualified":      []string{"true"},
+				},
+			},
+			expComps: []bundle.ComponentReference{
+				{ComponentName: "kubernetes", Version: "1.11.0"},
+				{ComponentName: "ann", Version: "1.1.0"},
+			},
+		},
+		{
+			desc:     "annotations: match qualified, exclude bad",
+			universe: annotationSet,
+			comps: []bundle.ComponentReference{
+				{ComponentName: "kubernetes"},
+			},
+			opts: &ResolveOptions{
+				Match: map[string][]string{
+					"cool-component": []string{"true"},
+					"qualified":      []string{"true"},
+				},
+				Exclude: map[string][]string{
+					"bad-component": []string{"true"},
+				},
+			},
+			expComps: []bundle.ComponentReference{
+				{ComponentName: "kubernetes", Version: "1.11.0"},
+				{ComponentName: "ann", Version: "1.0.0"},
+			},
+		},
+
+		////////////
+		// errors //
+		////////////
+		{
+			desc: "default private prevents being depended on",
+			universe: []string{
+				`
+kind: Component
+spec:
+  componentName: foo
+  version: 1.2.3
+`,
+				`
+kind: Component
+spec:
+  componentName: bar
+  version: 2.0.0
+  objects:
+  - kind: Requirements
+    require:
+    - componentName: foo`,
+			},
+			comps: []bundle.ComponentReference{
+				{ComponentName: "bar"},
+			},
+			expErrSubstr: "not visible",
+		},
+		{
+			desc:     "incompatible component combination from requirements",
+			universe: twoLayerCyclic,
+			comps: []bundle.ComponentReference{
+				{ComponentName: "foo", Version: "0.4.0"},
+			},
+			expErrSubstr: "component was fixed",
+		},
+		{
+			desc: "can't downgrade",
+			universe: []string{
+				`
+kind: Component
+spec:
+  componentName: foo
+  version: 1.2.3
+`,
+				`
+kind: Component
+spec:
+  componentName: bar
+  version: 2.0.0
+  objects:
+  - kind: Requirements
+    require:
+    - componentName: foo
+      version: 1.3`,
+			},
+			comps: []bundle.ComponentReference{
+				{ComponentName: "bar"},
+			},
+			expErrSubstr: "no previous version to 2.0.0",
+		},
+		{
+			desc:     "unknown component",
+			universe: twoLayerCyclic,
+			comps: []bundle.ComponentReference{
+				{ComponentName: "foo", Version: "0.5.0"},
+			},
+			expErrSubstr: "unknown component",
+		},
+		{
+			desc:     "bad visibility",
+			universe: apiVisibilityPattern,
+			comps: []bundle.ComponentReference{
+				{ComponentName: "bad-vis"},
+			},
+			expErrSubstr: "not visible",
+		},
+		{
+			desc:     "diagonal dependencies: can't downgrade",
+			universe: diagonalDeps,
+			comps: []bundle.ComponentReference{
+				{ComponentName: "high", Version: "1.1.0"},
+			},
+			expErrSubstr: "found incompatibility",
+		},
+		{
+			desc:     "annotations: can't match all",
+			universe: annotationSet,
+			comps: []bundle.ComponentReference{
+				{ComponentName: "kubernetes"},
+			},
+			opts: &ResolveOptions{
+				Match: map[string][]string{
+					"bad-component": []string{"true"},
+				},
+			},
+			expErrSubstr: "no latest version matching criteria",
+		},
+		{
+			desc:     "annotations: can't match any",
+			universe: annotationSet,
+			comps: []bundle.ComponentReference{
+				{ComponentName: "kubernetes"},
+			},
+			opts: &ResolveOptions{
+				Match: map[string][]string{
+					"zorp": []string{"true"},
+				},
+			},
+			expErrSubstr: "no latest version matching criteria",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			var parsedComps []*bundle.Component
+			for _, str := range tc.universe {
+				comp, err := converter.FromYAMLString(str).ToComponent()
+				if err != nil {
+					t.Fatal(err)
+				}
+				parsedComps = append(parsedComps, comp)
+			}
+
+			resolver, err := NewResolver(parsedComps)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			expMap := make(map[string]string)
+			for _, ec := range tc.expComps {
+				expMap[ec.ComponentName] = ec.Version
+			}
+
+			got, err := resolver.ResolveLatest(tc.comps, tc.opts)
+			if cerr := testutil.CheckErrorCases(err, tc.expErrSubstr); cerr != nil {
+				t.Fatal(cerr)
+			}
+			if err != nil {
+				return
+			}
+
+			gotMap := make(map[string]string)
+			for _, gc := range got {
+				gotMap[gc.ComponentName] = gc.Version
+			}
+
+			if !reflect.DeepEqual(gotMap, expMap) {
+				t.Errorf("Resolve(%v)=%v. Expected %v", tc.comps, got, tc.expComps)
+			}
+		})
+	}
+}

--- a/pkg/files/file_reader_writer.go
+++ b/pkg/files/file_reader_writer.go
@@ -104,7 +104,7 @@ func (r *LocalFileObjReader) ReadFileObj(ctx context.Context, file bundle.File) 
 	}
 	path, err := r.extractPath(file.URL)
 	if err != nil {
-		return nil, fmt.Errorf("file %v path could not be parsed: %v", err)
+		return nil, fmt.Errorf("file %v path could not be parsed: %v", file, err)
 	}
 	return r.Rdr.ReadFile(ctx, path)
 }

--- a/pkg/validate/validate_component.go
+++ b/pkg/validate/validate_component.go
@@ -39,11 +39,6 @@ var (
 	// TODO(kashomon): Use the K8S version validation for this.
 	// (k8s.io/apimachinery/pkg/util/version) after K8S v1.11
 	versionPattern = regexp.MustCompile(fmt.Sprintf(`^%s\.%s\.%s$`, numPattern, numPattern, numPattern))
-
-	// appVersionPattern matches app version string X.Y.Z or X.Y, where X, Y and
-	// Z are non-negative integers without leading zeros. Also can contain
-	// dangling extra info.
-	appVersionPattern = regexp.MustCompile(fmt.Sprintf(`^%s\.%s(\.%s(%s)?)?$`, numPattern, numPattern, numPattern, extraVersionInfo))
 )
 
 // Components validates a list of components.
@@ -93,12 +88,9 @@ func Component(c *bundle.Component) field.ErrorList {
 		errs = append(errs, field.Invalid(p.Child("Kind"), k, "kind must be Component"))
 	}
 
+	// TODO(kashomon): replace with semver library
 	if !versionPattern.MatchString(ver) {
 		errs = append(errs, field.Invalid(p.Child("Spec", "Version"), ver, "must be of the form X.Y.Z"))
-	}
-
-	if c.Spec.AppVersion != "" && !appVersionPattern.MatchString(c.Spec.AppVersion) {
-		errs = append(errs, field.Invalid(p.Child("Spec", "AppVersion"), ver, "must be of the form X.Y.Z or X.Y"))
 	}
 
 	return errs

--- a/pkg/validate/validate_component_test.go
+++ b/pkg/validate/validate_component_test.go
@@ -64,8 +64,7 @@ func TestValidateComponents(t *testing.T) {
           name: foo-comp-1.0.2
         spec:
           componentName: foo-comp
-          version: 2.10.1
-          appVersion: 3.10.1`,
+          version: 2.10.1`,
 			expectedErrors: 0,
 			description:    "basic component no refs",
 		},
@@ -77,8 +76,7 @@ func TestValidateComponents(t *testing.T) {
           name: foo-comp-1.0.2
         spec:
           componentName: foo-comp
-          version: 2.10.1
-          appVersion: 3.10`,
+          version: 2.10.1`,
 			expectedErrors: 0,
 			description:    "dot notation app version verification",
 		},
@@ -106,20 +104,6 @@ func TestValidateComponents(t *testing.T) {
 			expectedErrors: 1,
 			description:    "requires kind field to be specified",
 			errorDesc:      "kind must be Component",
-		},
-		{
-			componentConfig: `
-        apiVersion: 'bundle.gke.io/v1alpha1'
-        kind: Component
-        metadata:
-          name: foo-comp-1.0.2
-        spec:
-          componentName: foo-comp
-          version: 2.10.1
-          appVersion: 2.010.1   #invalid`,
-			expectedErrors: 1,
-			description:    "app version validation must be of form X.Y.Z",
-			errorDesc:      "must be of the form X.Y.Z or X.Y",
 		},
 		{
 			componentConfig: `

--- a/vendor/github.com/blang/semver/.travis.yml
+++ b/vendor/github.com/blang/semver/.travis.yml
@@ -1,0 +1,21 @@
+language: go
+matrix:
+  include:
+  - go: 1.4.3
+  - go: 1.5.4
+  - go: 1.6.3
+  - go: 1.7
+  - go: tip
+  allow_failures:
+  - go: tip
+install:
+- go get golang.org/x/tools/cmd/cover
+- go get github.com/mattn/goveralls
+script:
+- echo "Test and track coverage" ; $HOME/gopath/bin/goveralls -package "." -service=travis-ci
+  -repotoken $COVERALLS_TOKEN
+- echo "Build examples" ; cd examples && go build
+- echo "Check if gofmt'd" ; diff -u <(echo -n) <(gofmt -d -s .)
+env:
+  global:
+    secure: HroGEAUQpVq9zX1b1VIkraLiywhGbzvNnTZq2TMxgK7JHP8xqNplAeF1izrR2i4QLL9nsY+9WtYss4QuPvEtZcVHUobw6XnL6radF7jS1LgfYZ9Y7oF+zogZ2I5QUMRLGA7rcxQ05s7mKq3XZQfeqaNts4bms/eZRefWuaFZbkw=

--- a/vendor/github.com/blang/semver/BUILD.bazel
+++ b/vendor/github.com/blang/semver/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "json.go",
+        "range.go",
+        "semver.go",
+        "sort.go",
+        "sql.go",
+    ],
+    importmap = "github.com/GoogleCloudPlatform/k8s-cluster-bundle/vendor/github.com/blang/semver",
+    importpath = "github.com/blang/semver",
+    visibility = ["//visibility:public"],
+)

--- a/vendor/github.com/blang/semver/LICENSE
+++ b/vendor/github.com/blang/semver/LICENSE
@@ -1,0 +1,22 @@
+The MIT License
+
+Copyright (c) 2014 Benedikt Lang <github at benediktlang.de>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+

--- a/vendor/github.com/blang/semver/README.md
+++ b/vendor/github.com/blang/semver/README.md
@@ -1,0 +1,194 @@
+semver for golang [![Build Status](https://travis-ci.org/blang/semver.svg?branch=master)](https://travis-ci.org/blang/semver) [![GoDoc](https://godoc.org/github.com/blang/semver?status.png)](https://godoc.org/github.com/blang/semver) [![Coverage Status](https://img.shields.io/coveralls/blang/semver.svg)](https://coveralls.io/r/blang/semver?branch=master)
+======
+
+semver is a [Semantic Versioning](http://semver.org/) library written in golang. It fully covers spec version `2.0.0`.
+
+Usage
+-----
+```bash
+$ go get github.com/blang/semver
+```
+Note: Always vendor your dependencies or fix on a specific version tag.
+
+```go
+import github.com/blang/semver
+v1, err := semver.Make("1.0.0-beta")
+v2, err := semver.Make("2.0.0-beta")
+v1.Compare(v2)
+```
+
+Also check the [GoDocs](http://godoc.org/github.com/blang/semver).
+
+Why should I use this lib?
+-----
+
+- Fully spec compatible
+- No reflection
+- No regex
+- Fully tested (Coverage >99%)
+- Readable parsing/validation errors
+- Fast (See [Benchmarks](#benchmarks))
+- Only Stdlib
+- Uses values instead of pointers
+- Many features, see below
+
+
+Features
+-----
+
+- Parsing and validation at all levels
+- Comparator-like comparisons
+- Compare Helper Methods
+- InPlace manipulation
+- Ranges `>=1.0.0 <2.0.0 || >=3.0.0 !3.0.1-beta.1`
+- Wildcards `>=1.x`, `<=2.5.x`
+- Sortable (implements sort.Interface)
+- database/sql compatible (sql.Scanner/Valuer)
+- encoding/json compatible (json.Marshaler/Unmarshaler)
+
+Ranges
+------
+
+A `Range` is a set of conditions which specify which versions satisfy the range.
+
+A condition is composed of an operator and a version. The supported operators are:
+
+- `<1.0.0` Less than `1.0.0`
+- `<=1.0.0` Less than or equal to `1.0.0`
+- `>1.0.0` Greater than `1.0.0`
+- `>=1.0.0` Greater than or equal to `1.0.0`
+- `1.0.0`, `=1.0.0`, `==1.0.0` Equal to `1.0.0`
+- `!1.0.0`, `!=1.0.0` Not equal to `1.0.0`. Excludes version `1.0.0`.
+
+Note that spaces between the operator and the version will be gracefully tolerated.
+
+A `Range` can link multiple `Ranges` separated by space:
+
+Ranges can be linked by logical AND:
+
+  - `>1.0.0 <2.0.0` would match between both ranges, so `1.1.1` and `1.8.7` but not `1.0.0` or `2.0.0`
+  - `>1.0.0 <3.0.0 !2.0.3-beta.2` would match every version between `1.0.0` and `3.0.0` except `2.0.3-beta.2`
+
+Ranges can also be linked by logical OR:
+
+  - `<2.0.0 || >=3.0.0` would match `1.x.x` and `3.x.x` but not `2.x.x`
+
+AND has a higher precedence than OR. It's not possible to use brackets.
+
+Ranges can be combined by both AND and OR
+
+  - `>1.0.0 <2.0.0 || >3.0.0 !4.2.1` would match `1.2.3`, `1.9.9`, `3.1.1`, but not `4.2.1`, `2.1.1`
+
+Range usage:
+
+```
+v, err := semver.Parse("1.2.3")
+range, err := semver.ParseRange(">1.0.0 <2.0.0 || >=3.0.0")
+if range(v) {
+    //valid
+}
+
+```
+
+Example
+-----
+
+Have a look at full examples in [examples/main.go](examples/main.go)
+
+```go
+import github.com/blang/semver
+
+v, err := semver.Make("0.0.1-alpha.preview+123.github")
+fmt.Printf("Major: %d\n", v.Major)
+fmt.Printf("Minor: %d\n", v.Minor)
+fmt.Printf("Patch: %d\n", v.Patch)
+fmt.Printf("Pre: %s\n", v.Pre)
+fmt.Printf("Build: %s\n", v.Build)
+
+// Prerelease versions array
+if len(v.Pre) > 0 {
+    fmt.Println("Prerelease versions:")
+    for i, pre := range v.Pre {
+        fmt.Printf("%d: %q\n", i, pre)
+    }
+}
+
+// Build meta data array
+if len(v.Build) > 0 {
+    fmt.Println("Build meta data:")
+    for i, build := range v.Build {
+        fmt.Printf("%d: %q\n", i, build)
+    }
+}
+
+v001, err := semver.Make("0.0.1")
+// Compare using helpers: v.GT(v2), v.LT, v.GTE, v.LTE
+v001.GT(v) == true
+v.LT(v001) == true
+v.GTE(v) == true
+v.LTE(v) == true
+
+// Or use v.Compare(v2) for comparisons (-1, 0, 1):
+v001.Compare(v) == 1
+v.Compare(v001) == -1
+v.Compare(v) == 0
+
+// Manipulate Version in place:
+v.Pre[0], err = semver.NewPRVersion("beta")
+if err != nil {
+    fmt.Printf("Error parsing pre release version: %q", err)
+}
+
+fmt.Println("\nValidate versions:")
+v.Build[0] = "?"
+
+err = v.Validate()
+if err != nil {
+    fmt.Printf("Validation failed: %s\n", err)
+}
+```
+
+
+Benchmarks
+-----
+
+    BenchmarkParseSimple-4           5000000    390    ns/op    48 B/op   1 allocs/op
+    BenchmarkParseComplex-4          1000000   1813    ns/op   256 B/op   7 allocs/op
+    BenchmarkParseAverage-4          1000000   1171    ns/op   163 B/op   4 allocs/op
+    BenchmarkStringSimple-4         20000000    119    ns/op    16 B/op   1 allocs/op
+    BenchmarkStringLarger-4         10000000    206    ns/op    32 B/op   2 allocs/op
+    BenchmarkStringComplex-4         5000000    324    ns/op    80 B/op   3 allocs/op
+    BenchmarkStringAverage-4         5000000    273    ns/op    53 B/op   2 allocs/op
+    BenchmarkValidateSimple-4      200000000      9.33 ns/op     0 B/op   0 allocs/op
+    BenchmarkValidateComplex-4       3000000    469    ns/op     0 B/op   0 allocs/op
+    BenchmarkValidateAverage-4       5000000    256    ns/op     0 B/op   0 allocs/op
+    BenchmarkCompareSimple-4       100000000     11.8  ns/op     0 B/op   0 allocs/op
+    BenchmarkCompareComplex-4       50000000     30.8  ns/op     0 B/op   0 allocs/op
+    BenchmarkCompareAverage-4       30000000     41.5  ns/op     0 B/op   0 allocs/op
+    BenchmarkSort-4                  3000000    419    ns/op   256 B/op   2 allocs/op
+    BenchmarkRangeParseSimple-4      2000000    850    ns/op   192 B/op   5 allocs/op
+    BenchmarkRangeParseAverage-4     1000000   1677    ns/op   400 B/op  10 allocs/op
+    BenchmarkRangeParseComplex-4      300000   5214    ns/op  1440 B/op  30 allocs/op
+    BenchmarkRangeMatchSimple-4     50000000     25.6  ns/op     0 B/op   0 allocs/op
+    BenchmarkRangeMatchAverage-4    30000000     56.4  ns/op     0 B/op   0 allocs/op
+    BenchmarkRangeMatchComplex-4    10000000    153    ns/op     0 B/op   0 allocs/op
+
+See benchmark cases at [semver_test.go](semver_test.go)
+
+
+Motivation
+-----
+
+I simply couldn't find any lib supporting the full spec. Others were just wrong or used reflection and regex which i don't like.
+
+
+Contribution
+-----
+
+Feel free to make a pull request. For bigger changes create a issue first to discuss about it.
+
+
+License
+-----
+
+See [LICENSE](LICENSE) file.

--- a/vendor/github.com/blang/semver/json.go
+++ b/vendor/github.com/blang/semver/json.go
@@ -1,0 +1,23 @@
+package semver
+
+import (
+	"encoding/json"
+)
+
+// MarshalJSON implements the encoding/json.Marshaler interface.
+func (v Version) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.String())
+}
+
+// UnmarshalJSON implements the encoding/json.Unmarshaler interface.
+func (v *Version) UnmarshalJSON(data []byte) (err error) {
+	var versionString string
+
+	if err = json.Unmarshal(data, &versionString); err != nil {
+		return
+	}
+
+	*v, err = Parse(versionString)
+
+	return
+}

--- a/vendor/github.com/blang/semver/package.json
+++ b/vendor/github.com/blang/semver/package.json
@@ -1,0 +1,17 @@
+{
+  "author": "blang",
+  "bugs": {
+    "URL": "https://github.com/blang/semver/issues",
+    "url": "https://github.com/blang/semver/issues"
+  },
+  "gx": {
+    "dvcsimport": "github.com/blang/semver"
+  },
+  "gxVersion": "0.10.0",
+  "language": "go",
+  "license": "MIT",
+  "name": "semver",
+  "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
+  "version": "3.5.1"
+}
+

--- a/vendor/github.com/blang/semver/range.go
+++ b/vendor/github.com/blang/semver/range.go
@@ -1,0 +1,416 @@
+package semver
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"unicode"
+)
+
+type wildcardType int
+
+const (
+	noneWildcard  wildcardType = iota
+	majorWildcard wildcardType = 1
+	minorWildcard wildcardType = 2
+	patchWildcard wildcardType = 3
+)
+
+func wildcardTypefromInt(i int) wildcardType {
+	switch i {
+	case 1:
+		return majorWildcard
+	case 2:
+		return minorWildcard
+	case 3:
+		return patchWildcard
+	default:
+		return noneWildcard
+	}
+}
+
+type comparator func(Version, Version) bool
+
+var (
+	compEQ comparator = func(v1 Version, v2 Version) bool {
+		return v1.Compare(v2) == 0
+	}
+	compNE = func(v1 Version, v2 Version) bool {
+		return v1.Compare(v2) != 0
+	}
+	compGT = func(v1 Version, v2 Version) bool {
+		return v1.Compare(v2) == 1
+	}
+	compGE = func(v1 Version, v2 Version) bool {
+		return v1.Compare(v2) >= 0
+	}
+	compLT = func(v1 Version, v2 Version) bool {
+		return v1.Compare(v2) == -1
+	}
+	compLE = func(v1 Version, v2 Version) bool {
+		return v1.Compare(v2) <= 0
+	}
+)
+
+type versionRange struct {
+	v Version
+	c comparator
+}
+
+// rangeFunc creates a Range from the given versionRange.
+func (vr *versionRange) rangeFunc() Range {
+	return Range(func(v Version) bool {
+		return vr.c(v, vr.v)
+	})
+}
+
+// Range represents a range of versions.
+// A Range can be used to check if a Version satisfies it:
+//
+//     range, err := semver.ParseRange(">1.0.0 <2.0.0")
+//     range(semver.MustParse("1.1.1") // returns true
+type Range func(Version) bool
+
+// OR combines the existing Range with another Range using logical OR.
+func (rf Range) OR(f Range) Range {
+	return Range(func(v Version) bool {
+		return rf(v) || f(v)
+	})
+}
+
+// AND combines the existing Range with another Range using logical AND.
+func (rf Range) AND(f Range) Range {
+	return Range(func(v Version) bool {
+		return rf(v) && f(v)
+	})
+}
+
+// ParseRange parses a range and returns a Range.
+// If the range could not be parsed an error is returned.
+//
+// Valid ranges are:
+//   - "<1.0.0"
+//   - "<=1.0.0"
+//   - ">1.0.0"
+//   - ">=1.0.0"
+//   - "1.0.0", "=1.0.0", "==1.0.0"
+//   - "!1.0.0", "!=1.0.0"
+//
+// A Range can consist of multiple ranges separated by space:
+// Ranges can be linked by logical AND:
+//   - ">1.0.0 <2.0.0" would match between both ranges, so "1.1.1" and "1.8.7" but not "1.0.0" or "2.0.0"
+//   - ">1.0.0 <3.0.0 !2.0.3-beta.2" would match every version between 1.0.0 and 3.0.0 except 2.0.3-beta.2
+//
+// Ranges can also be linked by logical OR:
+//   - "<2.0.0 || >=3.0.0" would match "1.x.x" and "3.x.x" but not "2.x.x"
+//
+// AND has a higher precedence than OR. It's not possible to use brackets.
+//
+// Ranges can be combined by both AND and OR
+//
+//  - `>1.0.0 <2.0.0 || >3.0.0 !4.2.1` would match `1.2.3`, `1.9.9`, `3.1.1`, but not `4.2.1`, `2.1.1`
+func ParseRange(s string) (Range, error) {
+	parts := splitAndTrim(s)
+	orParts, err := splitORParts(parts)
+	if err != nil {
+		return nil, err
+	}
+	expandedParts, err := expandWildcardVersion(orParts)
+	if err != nil {
+		return nil, err
+	}
+	var orFn Range
+	for _, p := range expandedParts {
+		var andFn Range
+		for _, ap := range p {
+			opStr, vStr, err := splitComparatorVersion(ap)
+			if err != nil {
+				return nil, err
+			}
+			vr, err := buildVersionRange(opStr, vStr)
+			if err != nil {
+				return nil, fmt.Errorf("Could not parse Range %q: %s", ap, err)
+			}
+			rf := vr.rangeFunc()
+
+			// Set function
+			if andFn == nil {
+				andFn = rf
+			} else { // Combine with existing function
+				andFn = andFn.AND(rf)
+			}
+		}
+		if orFn == nil {
+			orFn = andFn
+		} else {
+			orFn = orFn.OR(andFn)
+		}
+
+	}
+	return orFn, nil
+}
+
+// splitORParts splits the already cleaned parts by '||'.
+// Checks for invalid positions of the operator and returns an
+// error if found.
+func splitORParts(parts []string) ([][]string, error) {
+	var ORparts [][]string
+	last := 0
+	for i, p := range parts {
+		if p == "||" {
+			if i == 0 {
+				return nil, fmt.Errorf("First element in range is '||'")
+			}
+			ORparts = append(ORparts, parts[last:i])
+			last = i + 1
+		}
+	}
+	if last == len(parts) {
+		return nil, fmt.Errorf("Last element in range is '||'")
+	}
+	ORparts = append(ORparts, parts[last:])
+	return ORparts, nil
+}
+
+// buildVersionRange takes a slice of 2: operator and version
+// and builds a versionRange, otherwise an error.
+func buildVersionRange(opStr, vStr string) (*versionRange, error) {
+	c := parseComparator(opStr)
+	if c == nil {
+		return nil, fmt.Errorf("Could not parse comparator %q in %q", opStr, strings.Join([]string{opStr, vStr}, ""))
+	}
+	v, err := Parse(vStr)
+	if err != nil {
+		return nil, fmt.Errorf("Could not parse version %q in %q: %s", vStr, strings.Join([]string{opStr, vStr}, ""), err)
+	}
+
+	return &versionRange{
+		v: v,
+		c: c,
+	}, nil
+
+}
+
+// inArray checks if a byte is contained in an array of bytes
+func inArray(s byte, list []byte) bool {
+	for _, el := range list {
+		if el == s {
+			return true
+		}
+	}
+	return false
+}
+
+// splitAndTrim splits a range string by spaces and cleans whitespaces
+func splitAndTrim(s string) (result []string) {
+	last := 0
+	var lastChar byte
+	excludeFromSplit := []byte{'>', '<', '='}
+	for i := 0; i < len(s); i++ {
+		if s[i] == ' ' && !inArray(lastChar, excludeFromSplit) {
+			if last < i-1 {
+				result = append(result, s[last:i])
+			}
+			last = i + 1
+		} else if s[i] != ' ' {
+			lastChar = s[i]
+		}
+	}
+	if last < len(s)-1 {
+		result = append(result, s[last:])
+	}
+
+	for i, v := range result {
+		result[i] = strings.Replace(v, " ", "", -1)
+	}
+
+	// parts := strings.Split(s, " ")
+	// for _, x := range parts {
+	// 	if s := strings.TrimSpace(x); len(s) != 0 {
+	// 		result = append(result, s)
+	// 	}
+	// }
+	return
+}
+
+// splitComparatorVersion splits the comparator from the version.
+// Input must be free of leading or trailing spaces.
+func splitComparatorVersion(s string) (string, string, error) {
+	i := strings.IndexFunc(s, unicode.IsDigit)
+	if i == -1 {
+		return "", "", fmt.Errorf("Could not get version from string: %q", s)
+	}
+	return strings.TrimSpace(s[0:i]), s[i:], nil
+}
+
+// getWildcardType will return the type of wildcard that the
+// passed version contains
+func getWildcardType(vStr string) wildcardType {
+	parts := strings.Split(vStr, ".")
+	nparts := len(parts)
+	wildcard := parts[nparts-1]
+
+	possibleWildcardType := wildcardTypefromInt(nparts)
+	if wildcard == "x" {
+		return possibleWildcardType
+	}
+
+	return noneWildcard
+}
+
+// createVersionFromWildcard will convert a wildcard version
+// into a regular version, replacing 'x's with '0's, handling
+// special cases like '1.x.x' and '1.x'
+func createVersionFromWildcard(vStr string) string {
+	// handle 1.x.x
+	vStr2 := strings.Replace(vStr, ".x.x", ".x", 1)
+	vStr2 = strings.Replace(vStr2, ".x", ".0", 1)
+	parts := strings.Split(vStr2, ".")
+
+	// handle 1.x
+	if len(parts) == 2 {
+		return vStr2 + ".0"
+	}
+
+	return vStr2
+}
+
+// incrementMajorVersion will increment the major version
+// of the passed version
+func incrementMajorVersion(vStr string) (string, error) {
+	parts := strings.Split(vStr, ".")
+	i, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return "", err
+	}
+	parts[0] = strconv.Itoa(i + 1)
+
+	return strings.Join(parts, "."), nil
+}
+
+// incrementMajorVersion will increment the minor version
+// of the passed version
+func incrementMinorVersion(vStr string) (string, error) {
+	parts := strings.Split(vStr, ".")
+	i, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return "", err
+	}
+	parts[1] = strconv.Itoa(i + 1)
+
+	return strings.Join(parts, "."), nil
+}
+
+// expandWildcardVersion will expand wildcards inside versions
+// following these rules:
+//
+// * when dealing with patch wildcards:
+// >= 1.2.x    will become    >= 1.2.0
+// <= 1.2.x    will become    <  1.3.0
+// >  1.2.x    will become    >= 1.3.0
+// <  1.2.x    will become    <  1.2.0
+// != 1.2.x    will become    <  1.2.0 >= 1.3.0
+//
+// * when dealing with minor wildcards:
+// >= 1.x      will become    >= 1.0.0
+// <= 1.x      will become    <  2.0.0
+// >  1.x      will become    >= 2.0.0
+// <  1.0      will become    <  1.0.0
+// != 1.x      will become    <  1.0.0 >= 2.0.0
+//
+// * when dealing with wildcards without
+// version operator:
+// 1.2.x       will become    >= 1.2.0 < 1.3.0
+// 1.x         will become    >= 1.0.0 < 2.0.0
+func expandWildcardVersion(parts [][]string) ([][]string, error) {
+	var expandedParts [][]string
+	for _, p := range parts {
+		var newParts []string
+		for _, ap := range p {
+			if strings.Index(ap, "x") != -1 {
+				opStr, vStr, err := splitComparatorVersion(ap)
+				if err != nil {
+					return nil, err
+				}
+
+				versionWildcardType := getWildcardType(vStr)
+				flatVersion := createVersionFromWildcard(vStr)
+
+				var resultOperator string
+				var shouldIncrementVersion bool
+				switch opStr {
+				case ">":
+					resultOperator = ">="
+					shouldIncrementVersion = true
+				case ">=":
+					resultOperator = ">="
+				case "<":
+					resultOperator = "<"
+				case "<=":
+					resultOperator = "<"
+					shouldIncrementVersion = true
+				case "", "=", "==":
+					newParts = append(newParts, ">="+flatVersion)
+					resultOperator = "<"
+					shouldIncrementVersion = true
+				case "!=", "!":
+					newParts = append(newParts, "<"+flatVersion)
+					resultOperator = ">="
+					shouldIncrementVersion = true
+				}
+
+				var resultVersion string
+				if shouldIncrementVersion {
+					switch versionWildcardType {
+					case patchWildcard:
+						resultVersion, _ = incrementMinorVersion(flatVersion)
+					case minorWildcard:
+						resultVersion, _ = incrementMajorVersion(flatVersion)
+					}
+				} else {
+					resultVersion = flatVersion
+				}
+
+				ap = resultOperator + resultVersion
+			}
+			newParts = append(newParts, ap)
+		}
+		expandedParts = append(expandedParts, newParts)
+	}
+
+	return expandedParts, nil
+}
+
+func parseComparator(s string) comparator {
+	switch s {
+	case "==":
+		fallthrough
+	case "":
+		fallthrough
+	case "=":
+		return compEQ
+	case ">":
+		return compGT
+	case ">=":
+		return compGE
+	case "<":
+		return compLT
+	case "<=":
+		return compLE
+	case "!":
+		fallthrough
+	case "!=":
+		return compNE
+	}
+
+	return nil
+}
+
+// MustParseRange is like ParseRange but panics if the range cannot be parsed.
+func MustParseRange(s string) Range {
+	r, err := ParseRange(s)
+	if err != nil {
+		panic(`semver: ParseRange(` + s + `): ` + err.Error())
+	}
+	return r
+}

--- a/vendor/github.com/blang/semver/semver.go
+++ b/vendor/github.com/blang/semver/semver.go
@@ -1,0 +1,418 @@
+package semver
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+const (
+	numbers  string = "0123456789"
+	alphas          = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-"
+	alphanum        = alphas + numbers
+)
+
+// SpecVersion is the latest fully supported spec version of semver
+var SpecVersion = Version{
+	Major: 2,
+	Minor: 0,
+	Patch: 0,
+}
+
+// Version represents a semver compatible version
+type Version struct {
+	Major uint64
+	Minor uint64
+	Patch uint64
+	Pre   []PRVersion
+	Build []string //No Precendence
+}
+
+// Version to string
+func (v Version) String() string {
+	b := make([]byte, 0, 5)
+	b = strconv.AppendUint(b, v.Major, 10)
+	b = append(b, '.')
+	b = strconv.AppendUint(b, v.Minor, 10)
+	b = append(b, '.')
+	b = strconv.AppendUint(b, v.Patch, 10)
+
+	if len(v.Pre) > 0 {
+		b = append(b, '-')
+		b = append(b, v.Pre[0].String()...)
+
+		for _, pre := range v.Pre[1:] {
+			b = append(b, '.')
+			b = append(b, pre.String()...)
+		}
+	}
+
+	if len(v.Build) > 0 {
+		b = append(b, '+')
+		b = append(b, v.Build[0]...)
+
+		for _, build := range v.Build[1:] {
+			b = append(b, '.')
+			b = append(b, build...)
+		}
+	}
+
+	return string(b)
+}
+
+// Equals checks if v is equal to o.
+func (v Version) Equals(o Version) bool {
+	return (v.Compare(o) == 0)
+}
+
+// EQ checks if v is equal to o.
+func (v Version) EQ(o Version) bool {
+	return (v.Compare(o) == 0)
+}
+
+// NE checks if v is not equal to o.
+func (v Version) NE(o Version) bool {
+	return (v.Compare(o) != 0)
+}
+
+// GT checks if v is greater than o.
+func (v Version) GT(o Version) bool {
+	return (v.Compare(o) == 1)
+}
+
+// GTE checks if v is greater than or equal to o.
+func (v Version) GTE(o Version) bool {
+	return (v.Compare(o) >= 0)
+}
+
+// GE checks if v is greater than or equal to o.
+func (v Version) GE(o Version) bool {
+	return (v.Compare(o) >= 0)
+}
+
+// LT checks if v is less than o.
+func (v Version) LT(o Version) bool {
+	return (v.Compare(o) == -1)
+}
+
+// LTE checks if v is less than or equal to o.
+func (v Version) LTE(o Version) bool {
+	return (v.Compare(o) <= 0)
+}
+
+// LE checks if v is less than or equal to o.
+func (v Version) LE(o Version) bool {
+	return (v.Compare(o) <= 0)
+}
+
+// Compare compares Versions v to o:
+// -1 == v is less than o
+// 0 == v is equal to o
+// 1 == v is greater than o
+func (v Version) Compare(o Version) int {
+	if v.Major != o.Major {
+		if v.Major > o.Major {
+			return 1
+		}
+		return -1
+	}
+	if v.Minor != o.Minor {
+		if v.Minor > o.Minor {
+			return 1
+		}
+		return -1
+	}
+	if v.Patch != o.Patch {
+		if v.Patch > o.Patch {
+			return 1
+		}
+		return -1
+	}
+
+	// Quick comparison if a version has no prerelease versions
+	if len(v.Pre) == 0 && len(o.Pre) == 0 {
+		return 0
+	} else if len(v.Pre) == 0 && len(o.Pre) > 0 {
+		return 1
+	} else if len(v.Pre) > 0 && len(o.Pre) == 0 {
+		return -1
+	}
+
+	i := 0
+	for ; i < len(v.Pre) && i < len(o.Pre); i++ {
+		if comp := v.Pre[i].Compare(o.Pre[i]); comp == 0 {
+			continue
+		} else if comp == 1 {
+			return 1
+		} else {
+			return -1
+		}
+	}
+
+	// If all pr versions are the equal but one has further prversion, this one greater
+	if i == len(v.Pre) && i == len(o.Pre) {
+		return 0
+	} else if i == len(v.Pre) && i < len(o.Pre) {
+		return -1
+	} else {
+		return 1
+	}
+
+}
+
+// Validate validates v and returns error in case
+func (v Version) Validate() error {
+	// Major, Minor, Patch already validated using uint64
+
+	for _, pre := range v.Pre {
+		if !pre.IsNum { //Numeric prerelease versions already uint64
+			if len(pre.VersionStr) == 0 {
+				return fmt.Errorf("Prerelease can not be empty %q", pre.VersionStr)
+			}
+			if !containsOnly(pre.VersionStr, alphanum) {
+				return fmt.Errorf("Invalid character(s) found in prerelease %q", pre.VersionStr)
+			}
+		}
+	}
+
+	for _, build := range v.Build {
+		if len(build) == 0 {
+			return fmt.Errorf("Build meta data can not be empty %q", build)
+		}
+		if !containsOnly(build, alphanum) {
+			return fmt.Errorf("Invalid character(s) found in build meta data %q", build)
+		}
+	}
+
+	return nil
+}
+
+// New is an alias for Parse and returns a pointer, parses version string and returns a validated Version or error
+func New(s string) (vp *Version, err error) {
+	v, err := Parse(s)
+	vp = &v
+	return
+}
+
+// Make is an alias for Parse, parses version string and returns a validated Version or error
+func Make(s string) (Version, error) {
+	return Parse(s)
+}
+
+// ParseTolerant allows for certain version specifications that do not strictly adhere to semver
+// specs to be parsed by this library. It does so by normalizing versions before passing them to
+// Parse(). It currently trims spaces, removes a "v" prefix, and adds a 0 patch number to versions
+// with only major and minor components specified
+func ParseTolerant(s string) (Version, error) {
+	s = strings.TrimSpace(s)
+	s = strings.TrimPrefix(s, "v")
+
+	// Split into major.minor.(patch+pr+meta)
+	parts := strings.SplitN(s, ".", 3)
+	if len(parts) < 3 {
+		if strings.ContainsAny(parts[len(parts)-1], "+-") {
+			return Version{}, errors.New("Short version cannot contain PreRelease/Build meta data")
+		}
+		for len(parts) < 3 {
+			parts = append(parts, "0")
+		}
+		s = strings.Join(parts, ".")
+	}
+
+	return Parse(s)
+}
+
+// Parse parses version string and returns a validated Version or error
+func Parse(s string) (Version, error) {
+	if len(s) == 0 {
+		return Version{}, errors.New("Version string empty")
+	}
+
+	// Split into major.minor.(patch+pr+meta)
+	parts := strings.SplitN(s, ".", 3)
+	if len(parts) != 3 {
+		return Version{}, errors.New("No Major.Minor.Patch elements found")
+	}
+
+	// Major
+	if !containsOnly(parts[0], numbers) {
+		return Version{}, fmt.Errorf("Invalid character(s) found in major number %q", parts[0])
+	}
+	if hasLeadingZeroes(parts[0]) {
+		return Version{}, fmt.Errorf("Major number must not contain leading zeroes %q", parts[0])
+	}
+	major, err := strconv.ParseUint(parts[0], 10, 64)
+	if err != nil {
+		return Version{}, err
+	}
+
+	// Minor
+	if !containsOnly(parts[1], numbers) {
+		return Version{}, fmt.Errorf("Invalid character(s) found in minor number %q", parts[1])
+	}
+	if hasLeadingZeroes(parts[1]) {
+		return Version{}, fmt.Errorf("Minor number must not contain leading zeroes %q", parts[1])
+	}
+	minor, err := strconv.ParseUint(parts[1], 10, 64)
+	if err != nil {
+		return Version{}, err
+	}
+
+	v := Version{}
+	v.Major = major
+	v.Minor = minor
+
+	var build, prerelease []string
+	patchStr := parts[2]
+
+	if buildIndex := strings.IndexRune(patchStr, '+'); buildIndex != -1 {
+		build = strings.Split(patchStr[buildIndex+1:], ".")
+		patchStr = patchStr[:buildIndex]
+	}
+
+	if preIndex := strings.IndexRune(patchStr, '-'); preIndex != -1 {
+		prerelease = strings.Split(patchStr[preIndex+1:], ".")
+		patchStr = patchStr[:preIndex]
+	}
+
+	if !containsOnly(patchStr, numbers) {
+		return Version{}, fmt.Errorf("Invalid character(s) found in patch number %q", patchStr)
+	}
+	if hasLeadingZeroes(patchStr) {
+		return Version{}, fmt.Errorf("Patch number must not contain leading zeroes %q", patchStr)
+	}
+	patch, err := strconv.ParseUint(patchStr, 10, 64)
+	if err != nil {
+		return Version{}, err
+	}
+
+	v.Patch = patch
+
+	// Prerelease
+	for _, prstr := range prerelease {
+		parsedPR, err := NewPRVersion(prstr)
+		if err != nil {
+			return Version{}, err
+		}
+		v.Pre = append(v.Pre, parsedPR)
+	}
+
+	// Build meta data
+	for _, str := range build {
+		if len(str) == 0 {
+			return Version{}, errors.New("Build meta data is empty")
+		}
+		if !containsOnly(str, alphanum) {
+			return Version{}, fmt.Errorf("Invalid character(s) found in build meta data %q", str)
+		}
+		v.Build = append(v.Build, str)
+	}
+
+	return v, nil
+}
+
+// MustParse is like Parse but panics if the version cannot be parsed.
+func MustParse(s string) Version {
+	v, err := Parse(s)
+	if err != nil {
+		panic(`semver: Parse(` + s + `): ` + err.Error())
+	}
+	return v
+}
+
+// PRVersion represents a PreRelease Version
+type PRVersion struct {
+	VersionStr string
+	VersionNum uint64
+	IsNum      bool
+}
+
+// NewPRVersion creates a new valid prerelease version
+func NewPRVersion(s string) (PRVersion, error) {
+	if len(s) == 0 {
+		return PRVersion{}, errors.New("Prerelease is empty")
+	}
+	v := PRVersion{}
+	if containsOnly(s, numbers) {
+		if hasLeadingZeroes(s) {
+			return PRVersion{}, fmt.Errorf("Numeric PreRelease version must not contain leading zeroes %q", s)
+		}
+		num, err := strconv.ParseUint(s, 10, 64)
+
+		// Might never be hit, but just in case
+		if err != nil {
+			return PRVersion{}, err
+		}
+		v.VersionNum = num
+		v.IsNum = true
+	} else if containsOnly(s, alphanum) {
+		v.VersionStr = s
+		v.IsNum = false
+	} else {
+		return PRVersion{}, fmt.Errorf("Invalid character(s) found in prerelease %q", s)
+	}
+	return v, nil
+}
+
+// IsNumeric checks if prerelease-version is numeric
+func (v PRVersion) IsNumeric() bool {
+	return v.IsNum
+}
+
+// Compare compares two PreRelease Versions v and o:
+// -1 == v is less than o
+// 0 == v is equal to o
+// 1 == v is greater than o
+func (v PRVersion) Compare(o PRVersion) int {
+	if v.IsNum && !o.IsNum {
+		return -1
+	} else if !v.IsNum && o.IsNum {
+		return 1
+	} else if v.IsNum && o.IsNum {
+		if v.VersionNum == o.VersionNum {
+			return 0
+		} else if v.VersionNum > o.VersionNum {
+			return 1
+		} else {
+			return -1
+		}
+	} else { // both are Alphas
+		if v.VersionStr == o.VersionStr {
+			return 0
+		} else if v.VersionStr > o.VersionStr {
+			return 1
+		} else {
+			return -1
+		}
+	}
+}
+
+// PreRelease version to string
+func (v PRVersion) String() string {
+	if v.IsNum {
+		return strconv.FormatUint(v.VersionNum, 10)
+	}
+	return v.VersionStr
+}
+
+func containsOnly(s string, set string) bool {
+	return strings.IndexFunc(s, func(r rune) bool {
+		return !strings.ContainsRune(set, r)
+	}) == -1
+}
+
+func hasLeadingZeroes(s string) bool {
+	return len(s) > 1 && s[0] == '0'
+}
+
+// NewBuildVersion creates a new valid build version
+func NewBuildVersion(s string) (string, error) {
+	if len(s) == 0 {
+		return "", errors.New("Buildversion is empty")
+	}
+	if !containsOnly(s, alphanum) {
+		return "", fmt.Errorf("Invalid character(s) found in build meta data %q", s)
+	}
+	return s, nil
+}

--- a/vendor/github.com/blang/semver/sort.go
+++ b/vendor/github.com/blang/semver/sort.go
@@ -1,0 +1,28 @@
+package semver
+
+import (
+	"sort"
+)
+
+// Versions represents multiple versions.
+type Versions []Version
+
+// Len returns length of version collection
+func (s Versions) Len() int {
+	return len(s)
+}
+
+// Swap swaps two versions inside the collection by its indices
+func (s Versions) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+// Less checks if version at index i is less than version at index j
+func (s Versions) Less(i, j int) bool {
+	return s[i].LT(s[j])
+}
+
+// Sort sorts a slice of versions
+func Sort(versions []Version) {
+	sort.Sort(Versions(versions))
+}

--- a/vendor/github.com/blang/semver/sql.go
+++ b/vendor/github.com/blang/semver/sql.go
@@ -1,0 +1,30 @@
+package semver
+
+import (
+	"database/sql/driver"
+	"fmt"
+)
+
+// Scan implements the database/sql.Scanner interface.
+func (v *Version) Scan(src interface{}) (err error) {
+	var str string
+	switch src := src.(type) {
+	case string:
+		str = src
+	case []byte:
+		str = string(src)
+	default:
+		return fmt.Errorf("Version.Scan: cannot convert %T to string.", src)
+	}
+
+	if t, err := Parse(str); err == nil {
+		*v = t
+	}
+
+	return
+}
+
+// Value implements the database/sql/driver.Valuer interface.
+func (v Version) Value() (driver.Value, error) {
+	return v.String(), nil
+}


### PR DESCRIPTION
This PR:

- Removes AppVersion and replaces with visibility in Requirements. This
  makes it much easier to reason about dependencies.
- Creates a new latest-version-perfering dependency solver
- Adds support for Match/Exclude labels during dependency selection
- Adds many tests to ensure everything works.