### PR TITLE
Basic benchmarks

### DIFF
--- a/pkg/build/BUILD.bazel
+++ b/pkg/build/BUILD.bazel
@@ -32,8 +32,10 @@ go_test(
     srcs = [
         "bazel_init_test.go",
         "config_map_maker_test.go",
+        "inline_benchmark_test.go",
         "inline_integration_test.go",
         "inline_test.go",
+        "patchbuild_benchmark_test.go",
         "patchbuild_test.go",
     ],
     data = ["//examples:testdata"],

--- a/pkg/build/inline_benchmark_test.go
+++ b/pkg/build/inline_benchmark_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC
+// Copyright 2019 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/build/inline_benchmark_test.go
+++ b/pkg/build/inline_benchmark_test.go
@@ -1,0 +1,38 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build
+
+import (
+	"context"
+	"io/ioutil"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/converter"
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/validate"
+)
+
+func BenchmarkBuildAndInline_Component(t *testing.B) {
+	b, _ := ioutil.ReadFile("../../examples/component/etcd-component-builder.yaml")
+	dataPath := "../../examples/component/etcd-component-builder.yaml"
+
+	for i := 0; i < t.N; i++ {
+		cb, _ := converter.FromYAML(b).ToComponentBuilder()
+		inliner := NewLocalInliner("../../examples/component/")
+		component, _:= inliner.ComponentFiles(context.Background(), cb, dataPath)
+		_, _ = converter.FromObject(component).ToYAML()
+		validate.Component(component)	
+	}
+
+}

--- a/pkg/build/inline_benchmark_test.go
+++ b/pkg/build/inline_benchmark_test.go
@@ -24,7 +24,11 @@ import (
 )
 
 func BenchmarkBuildAndInline_Component(t *testing.B) {
-	b, _ := ioutil.ReadFile("../../examples/component/etcd-component-builder.yaml")
+	b, err := ioutil.ReadFile("../../examples/component/etcd-component-builder.yaml")
+	if err != nil {
+		panic("error reading file")
+	}
+	
 	dataPath := "../../examples/component/etcd-component-builder.yaml"
 
 	for i := 0; i < t.N; i++ {

--- a/pkg/build/inline_benchmark_test.go
+++ b/pkg/build/inline_benchmark_test.go
@@ -26,7 +26,7 @@ import (
 func BenchmarkBuildAndInline_Component(t *testing.B) {
 	b, err := ioutil.ReadFile("../../examples/component/etcd-component-builder.yaml")
 	if err != nil {
-		panic("error reading file")
+		t.Fatal("error reading file")
 	}
 
 	dataPath := "../../examples/component/etcd-component-builder.yaml"
@@ -34,16 +34,16 @@ func BenchmarkBuildAndInline_Component(t *testing.B) {
 	for i := 0; i < t.N; i++ {
 		cb, err := converter.FromYAML(b).ToComponentBuilder()
 		if err != nil {
-			panic("error converting component")
+			t.Fatal("error converting component")
 		}
 		inliner := NewLocalInliner("../../examples/component/")
 		component, err := inliner.ComponentFiles(context.Background(), cb, dataPath)
 		if err != nil {
-			panic("error inlining components")
+			t.Fatal("error inlining components")
 		}
 		_, err = converter.FromObject(component).ToYAML()
 		if err != nil {
-			panic("error converting component")
+			t.Fatal("error converting component")
 		}
 		validate.Component(component)
 	}

--- a/pkg/build/inline_benchmark_test.go
+++ b/pkg/build/inline_benchmark_test.go
@@ -26,7 +26,7 @@ import (
 func BenchmarkBuildAndInline_Component(t *testing.B) {
 	b, err := ioutil.ReadFile("../../examples/component/etcd-component-builder.yaml")
 	if err != nil {
-		t.Fatal("error reading file")
+		t.Fatal(err)
 	}
 
 	dataPath := "../../examples/component/etcd-component-builder.yaml"
@@ -34,16 +34,16 @@ func BenchmarkBuildAndInline_Component(t *testing.B) {
 	for i := 0; i < t.N; i++ {
 		cb, err := converter.FromYAML(b).ToComponentBuilder()
 		if err != nil {
-			t.Fatal("error converting component")
+			t.Fatal(err)
 		}
 		inliner := NewLocalInliner("../../examples/component/")
 		component, err := inliner.ComponentFiles(context.Background(), cb, dataPath)
 		if err != nil {
-			t.Fatal("error inlining components")
+			t.Fatal(err)
 		}
 		_, err = converter.FromObject(component).ToYAML()
 		if err != nil {
-			t.Fatal("error converting component")
+			t.Fatal(err)
 		}
 		validate.Component(component)
 	}

--- a/pkg/build/inline_benchmark_test.go
+++ b/pkg/build/inline_benchmark_test.go
@@ -28,11 +28,20 @@ func BenchmarkBuildAndInline_Component(t *testing.B) {
 	dataPath := "../../examples/component/etcd-component-builder.yaml"
 
 	for i := 0; i < t.N; i++ {
-		cb, _ := converter.FromYAML(b).ToComponentBuilder()
+		cb, err := converter.FromYAML(b).ToComponentBuilder()
+		if err != nil {
+			panic("error converting component")
+		}
 		inliner := NewLocalInliner("../../examples/component/")
-		component, _:= inliner.ComponentFiles(context.Background(), cb, dataPath)
-		_, _ = converter.FromObject(component).ToYAML()
-		validate.Component(component)	
+		component, err:= inliner.ComponentFiles(context.Background(), cb, dataPath)
+		if err != nil {
+			panic("error inlining components")
+		}
+		_, err = converter.FromObject(component).ToYAML()
+		if err != nil {
+			panic("error converting component")
+		}
+		validate.Component(component)
 	}
 
 }

--- a/pkg/build/inline_benchmark_test.go
+++ b/pkg/build/inline_benchmark_test.go
@@ -28,7 +28,7 @@ func BenchmarkBuildAndInline_Component(t *testing.B) {
 	if err != nil {
 		panic("error reading file")
 	}
-	
+
 	dataPath := "../../examples/component/etcd-component-builder.yaml"
 
 	for i := 0; i < t.N; i++ {
@@ -37,7 +37,7 @@ func BenchmarkBuildAndInline_Component(t *testing.B) {
 			panic("error converting component")
 		}
 		inliner := NewLocalInliner("../../examples/component/")
-		component, err:= inliner.ComponentFiles(context.Background(), cb, dataPath)
+		component, err := inliner.ComponentFiles(context.Background(), cb, dataPath)
 		if err != nil {
 			panic("error inlining components")
 		}

--- a/pkg/build/patchbuild_benchmark_test.go
+++ b/pkg/build/patchbuild_benchmark_test.go
@@ -1,8 +1,23 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package build
 
 import (
 	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/converter"
 	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/filter"
+
 	"testing"
 )
 

--- a/pkg/build/patchbuild_benchmark_test.go
+++ b/pkg/build/patchbuild_benchmark_test.go
@@ -1,0 +1,97 @@
+
+
+package build
+
+import (
+  //"context"
+ // "io/ioutil"
+  "testing"
+
+  "github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/converter"
+  "github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/filter"
+
+ // "github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/validate"
+)
+/*
+      opts: map[string]interface{}{
+        "Namespace": "foo",
+      },
+      component: 
+
+
+          c, err := converter.FromYAMLString(tc.component).ToComponent()
+      if err != nil {
+        t.Fatalf("Error converting component %s: %v", tc.component, err)
+      }
+
+      newComp, err := ComponentPatchTemplates(c, tc.customFilter, tc.opts)
+      cerr := testutil.CheckErrorCases(err, tc.expErrSubstr)
+      if cerr != nil {
+        t.Error(cerr)
+      }
+      if err != nil {
+        // We hit an expected error, but we can't continue on because newComp is nil.
+        return
+      }
+
+      compBytes, err := converter.FromObject(newComp).ToYAML()
+      if err != nil {
+        t.Fatalf("Error converting back to yaml: %v", err)
+      }
+
+      compStr := strings.Trim(string(compBytes), " \n\r")
+      expStr := strings.Trim(tc.output, " \n\r")
+      if expStr != compStr {
+        t.Errorf("got yaml\n%s\n\nbut expected output yaml to be\n%s", compStr, expStr)
+      }
+    })
+*/
+func BenchmarkBuildAndPatch_Component(t *testing.B) {
+ /* b, _ := ioutil.ReadFile("../../examples/component/etcd-component-builder.yaml")
+  dataPath := "../../examples/component/etcd-component-builder.yaml"
+
+  for i := 0; i < t.N; i++ {
+    cb, _ := converter.FromYAML(b).ToComponentBuilder()
+    inliner := NewLocalInliner("../../examples/component/")
+    component, _:= inliner.ComponentFiles(context.Background(), cb, dataPath)
+    _, _ = converter.FromObject(component).ToYAML()
+    validate.Component(component) 
+  }*/
+
+  component := `
+kind: Component
+spec:
+  objects:
+  - apiVersion: v1
+    kind: Pod
+  - kind: PatchTemplateBuilder
+    apiVersion: bundle.gke.io/v1alpha1
+    buildSchema:
+      required:
+        - Namespace
+      properties:
+        Namespace:
+          type: string
+    targetSchema:
+      required:
+      - PodName
+      properties:
+        PodName:
+          type: string
+    template: |
+      kind: Pod
+      metadata:
+        namespace: {{.Namespace}}
+        name: {{.PodName}}`
+
+
+  for i := 0; i < t.N; i++ {
+      c, _ := converter.FromYAMLString(component).ToComponent()
+      newComp, _ := ComponentPatchTemplates(c, &filter.Options{}, map[string]interface{}{
+        "Namespace": "foo",
+      })
+      converter.FromObject(newComp).ToYAML()
+     
+  }
+
+}

--- a/pkg/build/patchbuild_benchmark_test.go
+++ b/pkg/build/patchbuild_benchmark_test.go
@@ -36,17 +36,17 @@ spec:
 	for i := 0; i < t.N; i++ {
 		c, err := converter.FromYAMLString(component).ToComponent()
 		if err != nil {
-			panic("error parsing component")
+			t.Fatal("error parsing component")
 		}
 		newComp, err := ComponentPatchTemplates(c, &filter.Options{}, map[string]interface{}{
 			"Namespace": "foo",
 		})
 		if err != nil {
-			panic("error patching component")
+			t.Fatal("error patching component")
 		}
 		_, err = converter.FromObject(newComp).ToYAML()
 		if err != nil {
-			panic("error converting object")
+			t.Fatal("error converting object")
 		}
 	}
 

--- a/pkg/build/patchbuild_benchmark_test.go
+++ b/pkg/build/patchbuild_benchmark_test.go
@@ -12,52 +12,7 @@ import (
 
  // "github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/validate"
 )
-/*
-      opts: map[string]interface{}{
-        "Namespace": "foo",
-      },
-      component: 
-
-
-          c, err := converter.FromYAMLString(tc.component).ToComponent()
-      if err != nil {
-        t.Fatalf("Error converting component %s: %v", tc.component, err)
-      }
-
-      newComp, err := ComponentPatchTemplates(c, tc.customFilter, tc.opts)
-      cerr := testutil.CheckErrorCases(err, tc.expErrSubstr)
-      if cerr != nil {
-        t.Error(cerr)
-      }
-      if err != nil {
-        // We hit an expected error, but we can't continue on because newComp is nil.
-        return
-      }
-
-      compBytes, err := converter.FromObject(newComp).ToYAML()
-      if err != nil {
-        t.Fatalf("Error converting back to yaml: %v", err)
-      }
-
-      compStr := strings.Trim(string(compBytes), " \n\r")
-      expStr := strings.Trim(tc.output, " \n\r")
-      if expStr != compStr {
-        t.Errorf("got yaml\n%s\n\nbut expected output yaml to be\n%s", compStr, expStr)
-      }
-    })
-*/
 func BenchmarkBuildAndPatch_Component(t *testing.B) {
- /* b, _ := ioutil.ReadFile("../../examples/component/etcd-component-builder.yaml")
-  dataPath := "../../examples/component/etcd-component-builder.yaml"
-
-  for i := 0; i < t.N; i++ {
-    cb, _ := converter.FromYAML(b).ToComponentBuilder()
-    inliner := NewLocalInliner("../../examples/component/")
-    component, _:= inliner.ComponentFiles(context.Background(), cb, dataPath)
-    _, _ = converter.FromObject(component).ToYAML()
-    validate.Component(component) 
-  }*/
-
   component := `
 kind: Component
 spec:
@@ -86,12 +41,20 @@ spec:
 
 
   for i := 0; i < t.N; i++ {
-      c, _ := converter.FromYAMLString(component).ToComponent()
-      newComp, _ := ComponentPatchTemplates(c, &filter.Options{}, map[string]interface{}{
+      c, err := converter.FromYAMLString(component).ToComponent()
+      if err != nil {
+	panic("error parsing component")
+      }
+      newComp, err := ComponentPatchTemplates(c, &filter.Options{}, map[string]interface{}{
         "Namespace": "foo",
       })
-      converter.FromObject(newComp).ToYAML()
-     
+      if err != nil {
+	panic("error patching component")
+      }
+      _, err = converter.FromObject(newComp).ToYAML()
+      if err != nil {
+	panic("error converting object")
+      }
   }
 
 }

--- a/pkg/build/patchbuild_benchmark_test.go
+++ b/pkg/build/patchbuild_benchmark_test.go
@@ -51,17 +51,17 @@ spec:
 	for i := 0; i < t.N; i++ {
 		c, err := converter.FromYAMLString(component).ToComponent()
 		if err != nil {
-			t.Fatal("error parsing component")
+			t.Fatal(err)
 		}
 		newComp, err := ComponentPatchTemplates(c, &filter.Options{}, map[string]interface{}{
 			"Namespace": "foo",
 		})
 		if err != nil {
-			t.Fatal("error patching component")
+			t.Fatal(err)
 		}
 		_, err = converter.FromObject(newComp).ToYAML()
 		if err != nil {
-			t.Fatal("error converting object")
+			t.Fatal(err)
 		}
 	}
 

--- a/pkg/build/patchbuild_benchmark_test.go
+++ b/pkg/build/patchbuild_benchmark_test.go
@@ -1,19 +1,13 @@
-
-
 package build
 
 import (
-  //"context"
- // "io/ioutil"
-  "testing"
-
-  "github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/converter"
-  "github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/filter"
-
- // "github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/validate"
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/converter"
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/filter"
+	"testing"
 )
+
 func BenchmarkBuildAndPatch_Component(t *testing.B) {
-  component := `
+	component := `
 kind: Component
 spec:
   objects:
@@ -39,22 +33,21 @@ spec:
         namespace: {{.Namespace}}
         name: {{.PodName}}`
 
-
-  for i := 0; i < t.N; i++ {
-      c, err := converter.FromYAMLString(component).ToComponent()
-      if err != nil {
-	panic("error parsing component")
-      }
-      newComp, err := ComponentPatchTemplates(c, &filter.Options{}, map[string]interface{}{
-        "Namespace": "foo",
-      })
-      if err != nil {
-	panic("error patching component")
-      }
-      _, err = converter.FromObject(newComp).ToYAML()
-      if err != nil {
-	panic("error converting object")
-      }
-  }
+	for i := 0; i < t.N; i++ {
+		c, err := converter.FromYAMLString(component).ToComponent()
+		if err != nil {
+			panic("error parsing component")
+		}
+		newComp, err := ComponentPatchTemplates(c, &filter.Options{}, map[string]interface{}{
+			"Namespace": "foo",
+		})
+		if err != nil {
+			panic("error patching component")
+		}
+		_, err = converter.FromObject(newComp).ToYAML()
+		if err != nil {
+			panic("error converting object")
+		}
+	}
 
 }

--- a/pkg/build/patchbuild_benchmark_test.go
+++ b/pkg/build/patchbuild_benchmark_test.go
@@ -15,10 +15,10 @@
 package build
 
 import (
+	"testing"
+
 	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/converter"
 	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/filter"
-
-	"testing"
 )
 
 func BenchmarkBuildAndPatch_Component(t *testing.B) {

--- a/pkg/commands/build/BUILD.bazel
+++ b/pkg/commands/build/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -16,4 +16,10 @@ go_library(
         "//vendor/github.com/spf13/cobra:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["benchmark_test.go"],
+    embed = [":go_default_library"],
 )

--- a/pkg/commands/build/BUILD.bazel
+++ b/pkg/commands/build/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
@@ -16,10 +16,4 @@ go_library(
         "//vendor/github.com/spf13/cobra:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],
-)
-
-go_test(
-    name = "go_default_test",
-    srcs = ["benchmark_test.go"],
-    embed = [":go_default_library"],
 )

--- a/pkg/options/gotmpl/BUILD.bazel
+++ b/pkg/options/gotmpl/BUILD.bazel
@@ -16,7 +16,10 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    srcs = ["go_template_applier_test.go"],
+    srcs = [
+        "go_template_applier_benchmark_test.go",
+        "go_template_applier_test.go",
+    ],
     embed = [":go_default_library"],
     deps = [
         "//pkg/converter:go_default_library",

--- a/pkg/options/gotmpl/go_template_applier_benchmark_test.go
+++ b/pkg/options/gotmpl/go_template_applier_benchmark_test.go
@@ -1,0 +1,74 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gotmpl
+
+import (
+	"testing"
+
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/converter"
+)
+
+func BenchmarkGoTemplateApplier(t *testing.B){
+  component := `kind: Component
+spec:
+  componentName: data-component
+  objects:
+  - kind: ObjectTemplate
+    type: go-template
+    template: |
+      apiVersion: v1
+      kind: Pod
+      metadata:
+        name: logger-pod
+      spec:
+        dnsPolicy: '{{.DNSPolicy}}'
+        containers:
+        - name: logger
+          image: '{{.ContainerImage}}'
+  - kind: ObjectTemplate
+    metadata:
+      name: logger-pod-no-inline
+    type: go-template
+    template: |
+      apiVersion: v1
+      kind: Pod
+      metadata:
+        name: logger-pod
+      spec:
+        dnsPolicy: '{{.AnotherDNSPolicy}}'
+        containers:
+        - name: logger
+          image: '{{.AnotherContainerImage}}'`
+
+  templates := map[string]interface{}{
+    "DNSPolicy": "FooBarPolicy",
+    "ContainerImage":        "MyContainerImage",
+    "AnotherDNSPolicy":      "BlooBlarPolicy",
+    "AnotherContainerImage": "AnotherContainerImageVal",
+  }
+
+  for i := 0; i < t.N; i++ {
+    comp, err := converter.FromYAMLString(component).ToComponent()
+    if err != nil {
+      t.Fatal(err)
+    }
+
+    _, err = NewApplier().ApplyOptions(comp, templates)
+    if err != nil {
+      t.Fatal(err)
+    }  
+  }
+  
+}

--- a/pkg/options/gotmpl/go_template_applier_benchmark_test.go
+++ b/pkg/options/gotmpl/go_template_applier_benchmark_test.go
@@ -20,8 +20,8 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/converter"
 )
 
-func BenchmarkGoTemplateApplier(t *testing.B){
-  component := `kind: Component
+func BenchmarkGoTemplateApplier(t *testing.B) {
+	component := `kind: Component
 spec:
   componentName: data-component
   objects:
@@ -52,23 +52,23 @@ spec:
         - name: logger
           image: '{{.AnotherContainerImage}}'`
 
-  templates := map[string]interface{}{
-    "DNSPolicy": "FooBarPolicy",
-    "ContainerImage":        "MyContainerImage",
-    "AnotherDNSPolicy":      "BlooBlarPolicy",
-    "AnotherContainerImage": "AnotherContainerImageVal",
-  }
+	templates := map[string]interface{}{
+		"DNSPolicy":             "FooBarPolicy",
+		"ContainerImage":        "MyContainerImage",
+		"AnotherDNSPolicy":      "BlooBlarPolicy",
+		"AnotherContainerImage": "AnotherContainerImageVal",
+	}
 
-  for i := 0; i < t.N; i++ {
-    comp, err := converter.FromYAMLString(component).ToComponent()
-    if err != nil {
-      t.Fatal(err)
-    }
+	for i := 0; i < t.N; i++ {
+		comp, err := converter.FromYAMLString(component).ToComponent()
+		if err != nil {
+			t.Fatal(err)
+		}
 
-    _, err = NewApplier().ApplyOptions(comp, templates)
-    if err != nil {
-      t.Fatal(err)
-    }  
-  }
-  
+		_, err = NewApplier().ApplyOptions(comp, templates)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
 }

--- a/pkg/options/patchtmpl/BUILD.bazel
+++ b/pkg/options/patchtmpl/BUILD.bazel
@@ -33,7 +33,10 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    srcs = ["patch_test.go"],
+    srcs = [
+        "patch_benchmark_test.go",
+        "patch_test.go",
+    ],
     embed = [":go_default_library"],
     deps = [
         "//pkg/converter:go_default_library",

--- a/pkg/options/patchtmpl/patch_benchmark_test.go
+++ b/pkg/options/patchtmpl/patch_benchmark_test.go
@@ -1,0 +1,65 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package patchtmpl
+
+import (
+	"testing"
+
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/converter"
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/filter"
+)
+
+func BenchmarkPatchTemplateApplier(t *testing.B) {
+	component := `kind: Component
+spec:
+  objects:
+  - apiVersion: v1
+    kind: Pod
+    metadata:
+      namespace: derp
+  - kind: PatchTemplate
+    template: |
+      kind: Pod
+      metadata:
+        namespace: {{.Name}}
+  - kind: PatchTemplate
+    template: |
+      kind: Pod
+      metadata:
+        annotations:
+          fooAnnot: {{.Annot}}
+`
+	patchOptions := map[string]interface{}{
+		"Name":  "doom",
+		"Annot": "slayer",
+	}
+	customFilter := &filter.Options{
+		Annotations: map[string]string{
+			"phase": "build",
+		},
+	}
+
+	for i := 0; i < t.N; i++ {
+		patcher := NewApplier(DefaultPatcherScheme(), customFilter, true)
+		compObj, err := converter.FromYAMLString(component).ToComponent()
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, err = patcher.ApplyOptions(compObj, patchOptions)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
These are only basic tests, but I'm getting 
BenchmarkBuildAndInline_Component-12    	     500	   2733579 ns/op
BenchmarkBuildAndPatch_Component-12     	    2000	   1076068 ns/op

on my local pc, and I'm even hitting the file system in places.  I don't think it matters.  
Think it's a waste of time to benchmark this  Our db latency is multiple levels of magnitude larger than this, so it doesn't really make much sense to care about this.  .  

Patch tests:
BenchmarkGoTemplateApplier-12    	    3000	    620792 ns/op
BenchmarkPatchTemplateApplier-12    	   10000	    137668 ns/op
