### PR TITLE
Two cleanups for dependency resolution:

### DIFF
--- a/pkg/deps/annotation_matcher.go
+++ b/pkg/deps/annotation_matcher.go
@@ -49,6 +49,9 @@ type AnnotationCriteria struct {
 	// If there are multiple keys (annotations) specified, then all annotations
 	// must match.  In other words, this is a logical AND operation of the passed
 	// in Annotation and the component Annotation.
+	//
+	// If the list of values is empty, then the annotation is matched for any
+	// annotation value.
 	Match map[string][]string
 
 	// Exclude are component annotations that must not be present.  This is
@@ -59,6 +62,9 @@ type AnnotationCriteria struct {
 	// Unlike Match, if a there are multiple keys (annotations) specified, then
 	// only one of the annotations need be matched in order for the component to
 	// be excluded.
+	//
+	// If the list of values is empty, then the annotation is matched
+	// for any annotation value.
 	Exclude map[string][]string
 }
 
@@ -75,9 +81,12 @@ func AnnotationMatcher(criteria *AnnotationCriteria) Matcher {
 		}
 
 		matchesAnnot := func(key string, vals []string, annots map[string]string) bool {
+			if _, ok := annots[key]; ok && len(vals) == 0 {
+				return true
+			}
 			matchesAny := false
 			for _, val := range vals {
-				if m.Annotations[key] == val {
+				if annots[key] == val {
 					matchesAny = true
 					break
 				}

--- a/pkg/deps/annotation_matcher.go
+++ b/pkg/deps/annotation_matcher.go
@@ -84,18 +84,18 @@ func AnnotationMatcher(criteria *AnnotationCriteria) Matcher {
 			if _, ok := annots[key]; ok && len(vals) == 0 {
 				return true
 			}
-			matchesAny := false
 			for _, val := range vals {
 				if annots[key] == val {
-					matchesAny = true
+					return true
 					break
 				}
 			}
-			return matchesAny
+			return false
 		}
 
 		match := true
 		for key, vals := range criteria.Match {
+			// match must match all; stop when it doesn't.
 			if !matchesAnnot(key, vals, m.Annotations) {
 				match = false
 				break
@@ -104,6 +104,7 @@ func AnnotationMatcher(criteria *AnnotationCriteria) Matcher {
 
 		exclude := false
 		for key, vals := range criteria.Exclude {
+			// exclude matches any; stop when you match
 			if matchesAnnot(key, vals, m.Annotations) {
 				exclude = true
 				break

--- a/pkg/deps/annotation_matcher_test.go
+++ b/pkg/deps/annotation_matcher_test.go
@@ -264,7 +264,7 @@ func TestAnnotationMatcher(t *testing.T) {
 			expMatch: false,
 		},
 		{
-			desc: "ann-1.0.0, both exclude and match: exclude wins ",
+			desc: "ann-1.0.0, both exclude and match: exclude wins",
 			ref: bundle.ComponentReference{
 				ComponentName: "ann",
 				Version:       "1.0.0",
@@ -275,6 +275,32 @@ func TestAnnotationMatcher(t *testing.T) {
 				},
 				Exclude: map[string][]string{
 					"channel": []string{"stable"},
+				},
+			},
+			expMatch: false,
+		},
+		{
+			desc: "ann-1.0.0, empty vals matches whenever an annotation exists",
+			ref: bundle.ComponentReference{
+				ComponentName: "ann",
+				Version:       "1.0.0",
+			},
+			criteria: &AnnotationCriteria{
+				Match: map[string][]string{
+					"channel": []string{},
+				},
+			},
+			expMatch: true,
+		},
+		{
+			desc: "ann-1.0.0, empty vals excludes whenever an annotation exists",
+			ref: bundle.ComponentReference{
+				ComponentName: "ann",
+				Version:       "1.0.0",
+			},
+			criteria: &AnnotationCriteria{
+				Exclude: map[string][]string{
+					"channel": []string{},
 				},
 			},
 			expMatch: false,

--- a/pkg/deps/resolve.go
+++ b/pkg/deps/resolve.go
@@ -74,11 +74,12 @@ func (r *Resolver) AllComponents() []*bundle.Component {
 	return out
 }
 
-// ComponentVersions gets the versions for a particular component
-func (r *Resolver) ComponentVersions(comp string) ([]bundle.ComponentReference, error) {
+// ComponentVersions gets the versions for a particular component, returning an
+// empty list of component references if the component cannot be found.
+func (r *Resolver) ComponentVersions(comp string) []bundle.ComponentReference {
 	cv, ok := r.componentVersions[comp]
 	if !ok {
-		return nil, fmt.Errorf("unknown component %q", comp)
+		return nil
 	}
 	var versions []bundle.ComponentReference
 	for _, ver := range cv.versions {
@@ -87,7 +88,7 @@ func (r *Resolver) ComponentVersions(comp string) ([]bundle.ComponentReference, 
 			Version:       ver.version.String(),
 		})
 	}
-	return versions, nil
+	return versions
 }
 
 // ResolveOptions are options for resolving dependencies
@@ -132,11 +133,7 @@ func (r *Resolver) Resolve(refs []bundle.ComponentReference, opts *ResolveOption
 		} else {
 			m, ok := r.metaLookup[ref]
 			if !ok {
-				versions, err := r.ComponentVersions(ref.ComponentName)
-				if err != nil {
-					return nil, err
-				}
-				return nil, fmt.Errorf("unknown component %v; known versions are %v", ref, versions)
+				return nil, fmt.Errorf("unknown component %v; known versions are %v", ref, r.ComponentVersions(ref.ComponentName))
 			}
 			exact = append(exact, m)
 		}


### PR DESCRIPTION
1.  Don't return an error from ComponentVersions. Just return an empty list.
    This is a cleaner / more standard API.
2.  For annotation matching, if the list of values is empty, match anything.
    
Fixes: #276.