### PR TITLE
Add an error in the case of nil objects.

### DIFF
--- a/pkg/deps/meta.go
+++ b/pkg/deps/meta.go
@@ -102,7 +102,10 @@ func metaFromComponent(c *bundle.Component, proc MatchProcessor) (*depMeta, erro
 	}
 
 	var req *bundle.Requirements
-	for _, o := range c.Spec.Objects {
+	for i, o := range c.Spec.Objects {
+		if o == nil {
+			return nil, fmt.Errorf("component %v contained a nil object at index %d", m.ref(), i)
+		}
 		if o.GetKind() != "Requirements" {
 			continue
 		}


### PR DESCRIPTION
This shouldn't happen, but has happened before due to parsing bugs. In
this case, throw an error rather than panic'ing.