### PR TITLE
Some fixes to relative path handling

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -17,6 +17,7 @@ go_test(
         "bazel_init_test.go",
         "examples_test.go",
     ],
+    data = [":testdata"],
     deps = [
         "//pkg/testutil:go_default_library",
         "//pkg/testutil/componentsuite:go_default_library",

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_test")
+
 filegroup(
     name = "testdata",
     srcs = [
@@ -7,4 +9,16 @@ filegroup(
         "//examples/patchbuilder:testdata",
     ],
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "bazel_init_test.go",
+        "examples_test.go",
+    ],
+    deps = [
+        "//pkg/testutil:go_default_library",
+        "//pkg/testutil/componentsuite:go_default_library",
+    ],
 )

--- a/examples/bazel_init_test.go
+++ b/examples/bazel_init_test.go
@@ -1,0 +1,23 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package examples_test
+
+import (
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/testutil"
+)
+
+func init() {
+	testutil.ChangeToBazelDir("examples")
+}

--- a/examples/component/test-suite.yaml
+++ b/examples/component/test-suite.yaml
@@ -1,5 +1,4 @@
 componentFile: etcd-component-builder.yaml
-rootDirectory: './'
 
 testCases:
 - description: Success

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -1,0 +1,27 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package examples_test
+
+import (
+	"testing"
+
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/testutil/componentsuite"
+)
+
+func TestComponentSuite(t *testing.T) {
+	// This provides a variation on relative path reading, as compared to the
+	// test-suite runner in the component directory.
+	componentsuite.Run(t, "component/test-suite.yaml")
+}

--- a/pkg/build/inline.go
+++ b/pkg/build/inline.go
@@ -61,7 +61,7 @@ func NewInlinerWithScheme(scheme files.URLScheme, objReader files.FileObjReader)
 	}
 }
 
-// BundleFiles converts dereferences file-references in for bundle files. If
+// BundleFiles inlines file-references in for bundle files. If
 // the bundlePath is defined and not absolute and the scheme is file based
 // scheme, then the path is made absolute before proceeding.
 func (n *Inliner) BundleFiles(ctx context.Context, data *bundle.BundleBuilder, bundlePath string) (*bundle.Bundle, error) {
@@ -224,7 +224,7 @@ func (n *Inliner) objectFiles(ctx context.Context, objFiles []bundle.File, ref b
 
 		contents, err := n.readFile(ctx, cf)
 		if err != nil {
-			return nil, nil, fmt.Errorf("reading file %v for component %v: %v", cf, ref, err)
+			return nil, nil, fmt.Errorf("error reading file %v for component %v: %v", cf, ref, err)
 		}
 		ext := filepath.Ext(cf.URL)
 		if ext == ".yaml" && multiDoc.Match(contents) {

--- a/pkg/build/inline.go
+++ b/pkg/build/inline.go
@@ -65,13 +65,19 @@ func NewInlinerWithScheme(scheme files.URLScheme, objReader files.FileObjReader)
 	}
 }
 
-// BundleFiles converts dereferences file-references in for bundle files. The
-// bundlePath must be an absolute path path this point.
+// BundleFiles converts dereferences file-references in for bundle files. If
+// the bundlePath is defined and not absolute and the scheme is file based
+// scheme, then the path is made absolute before proceeding.
 func (n *Inliner) BundleFiles(ctx context.Context, data *bundle.BundleBuilder, bundlePath string) (*bundle.Bundle, error) {
 	bundleURL, err := url.Parse(bundlePath)
 	if err != nil {
 		return nil, err
 	}
+	bundleURL, err = n.PathRewriter.Abs(bundleURL)
+	if err != nil {
+		return nil, err
+	}
+
 	if !filepath.IsAbs(bundleURL.Path) {
 		return nil, fmt.Errorf("bundlePath must be absolute but was %s", bundleURL.Path)
 	}
@@ -81,7 +87,7 @@ func (n *Inliner) BundleFiles(ctx context.Context, data *bundle.BundleBuilder, b
 		if err != nil {
 			return nil, err
 		}
-		f.URL = n.PathRewriter.MakeAbs(bundleURL, furl).String()
+		f.URL = n.PathRewriter.AbsWithParent(bundleURL, furl).String()
 
 		contents, err := n.readFile(ctx, f)
 		if err != nil {
@@ -136,13 +142,20 @@ var multiDoc = regexp.MustCompile("(^|\n)---")
 var nonDNS = regexp.MustCompile(`[^-a-z0-9\.]`)
 
 // ComponentFiles reads file-references for component builder objects.  The
-// returned components are copies with the file-references removed. The
-// componentPath must be an absolute path at this point.
+// returned components are copies with the file-references removed. If the
+// componentPath is not absolute and the scheme is a file scheme, it will be
+// made absolute before proceeding.
 func (n *Inliner) ComponentFiles(ctx context.Context, comp *bundle.ComponentBuilder, componentPath string) (*bundle.Component, error) {
 	componentURL, err := url.Parse(componentPath)
 	if err != nil {
 		return nil, err
 	}
+	componentURL, err = n.PathRewriter.Abs(componentURL)
+	if err != nil {
+		return nil, err
+	}
+
+	componentURL = n.PathRewriter.AbsWithParent(nil, componentURL)
 	if !filepath.IsAbs(componentURL.Path) {
 		return nil, fmt.Errorf("componentPath must be absolute but was %s", componentURL.Path)
 	}
@@ -214,7 +227,7 @@ func (n *Inliner) objectFiles(ctx context.Context, objFiles []bundle.File, ref b
 		if err != nil {
 			return nil, nil, err
 		}
-		cf.URL = n.PathRewriter.MakeAbs(componentPath, furl).String()
+		cf.URL = n.PathRewriter.AbsWithParent(componentPath, furl).String()
 
 		contents, err := n.readFile(ctx, cf)
 		if err != nil {
@@ -282,7 +295,7 @@ func (n *Inliner) objectTemplateBuilders(ctx context.Context, objects map[string
 				return nil, err
 			}
 
-			builder.File.URL = n.PathRewriter.MakeAbs(parentURL, furl).String()
+			builder.File.URL = n.PathRewriter.AbsWithParent(parentURL, furl).String()
 
 			contents, err := n.readFile(ctx, builder.File)
 			if err != nil {
@@ -338,7 +351,7 @@ func (n *Inliner) rawTextFiles(ctx context.Context, fileGroups []bundle.FileGrou
 			if err != nil {
 				return nil, err
 			}
-			cf.URL = n.PathRewriter.MakeAbs(componentPath, furl).String()
+			cf.URL = n.PathRewriter.AbsWithParent(componentPath, furl).String()
 
 			text, err := n.readFile(ctx, cf)
 			if err != nil {

--- a/pkg/build/inline_test.go
+++ b/pkg/build/inline_test.go
@@ -645,7 +645,7 @@ metadata:
 			desc:         "fail: can't read file",
 			data:         kubeApiserverComponent,
 			files:        make(map[string][]byte),
-			expErrSubstr: "error reading file",
+			expErrSubstr: "reading file",
 		},
 		{
 			desc: "fail: can't read raw text file",

--- a/pkg/build/path_rewriter.go
+++ b/pkg/build/path_rewriter.go
@@ -36,9 +36,6 @@ func (rw *RelativePathRewriter) MakeAbs(parent, obj *url.URL) *url.URL {
 		// Only file schemes are supported.
 		return obj
 	}
-	if !filepath.IsAbs(parent.Path) {
-		return obj
-	}
 	if filepath.IsAbs(obj.Path) {
 		return obj
 	}

--- a/pkg/commands/cmdlib/bundleio.go
+++ b/pkg/commands/cmdlib/bundleio.go
@@ -135,16 +135,8 @@ func (brw *realBundleReaderWriter) ReadBundleData(ctx context.Context, g *Global
 
 // inlineData inlines a cluster bundle before processing
 func (brw *realBundleReaderWriter) inlineData(ctx context.Context, bw *wrapper.BundleWrapper, g *GlobalOptions) (*wrapper.BundleWrapper, error) {
-	var err error
 	infile := g.InputFile
-	if !filepath.IsAbs(infile) {
-		infile, err = filepath.Abs(infile)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	inliner := brw.makeInlinerFn(brw.rw, g.InputFile)
+	inliner := brw.makeInlinerFn(brw.rw, infile)
 	switch bw.Kind() {
 	case "BundleBuilder":
 		newBun, err := inliner.BundleFiles(ctx, bw.BundleBuilder(), infile)

--- a/pkg/commands/cmdlib/bundleio_test.go
+++ b/pkg/commands/cmdlib/bundleio_test.go
@@ -216,7 +216,7 @@ spec:
 			readFile:      componentBuilderEx,
 			inlineCompOut: componentEx,
 			inlineErr:     errors.New("zork"),
-			expErrSubstr:  "error inlining objects",
+			expErrSubstr:  "inlining objects",
 		},
 	}
 

--- a/pkg/converter/converter_test.go
+++ b/pkg/converter/converter_test.go
@@ -43,7 +43,7 @@ spec:
     resources:
       requests:
         cpu: 10m
-        memory: 100Mi
+        memory: 101Mi
     volumeMounts:
     - mountPath: /var/log/rescheduler.log
       name: logfile

--- a/pkg/testutil/componentsuite/schema.go
+++ b/pkg/testutil/componentsuite/schema.go
@@ -24,7 +24,8 @@ type ComponentTestSuite struct {
 	// file.
 	ComponentFile string `json:"componentFile"`
 
-	// RootDirectory is the path to a root-directory.
+	// RootDirectory is the path to a root-directory to run the tests. If not
+	// specified, sets the root directory to the test-suite file directory.
 	RootDirectory string `json:"rootDirectory"`
 
 	// TestCases contains a list of component TestCases.

--- a/pkg/testutil/testutil.go
+++ b/pkg/testutil/testutil.go
@@ -35,3 +35,16 @@ func ChangeToBazelDir(curDir string) {
 		}
 	}
 }
+
+// ChangeToBazelDirWithoutWorkspace, like ChangeToBazelDir, changes the CWD to
+// a bazel directory if necessary, but doesn't use the workspace path as part
+// of the path building. If changing the directory fails, the method panics.
+func ChangeToBazelDirWithoutWorkspace(curDir string) {
+	bazelTestPath := os.Getenv("TEST_SRCDIR")
+	if bazelTestPath != "" {
+		dir := filepath.Join(bazelTestPath, curDir)
+		if err := os.Chdir(dir); err != nil {
+			panic(fmt.Sprintf("os.Chdir(%q): %v", dir, err))
+		}
+	}
+}


### PR DESCRIPTION
Now, in bundleio, make the component / bundle files absolute as soon as
possible and return an error in the inliner if they are not absolute.

Also: Fix relative path issues in component testsuite

Fixes:#279
Fixes #274