### PR TITLE
Add support for already-inlined objects in ComponentBuilder

### DIFF
--- a/pkg/apis/bundle/v1alpha1/builder_types.go
+++ b/pkg/apis/bundle/v1alpha1/builder_types.go
@@ -16,6 +16,7 @@ package v1alpha1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -61,7 +62,7 @@ type ComponentBuilder struct {
 	// more details. The version is optional for the ComponentBuilder.
 	Version string `json:"version,omitempty"`
 
-	// Objects that are specified via a File-URL. The process of inlining a
+	// ObjectFiles that are specified via a File-URL. The process of inlining a
 	// component turns object files into objects.  During the inline process, if
 	// the file is YAML-formatted and contains multiple objects in the YAML-doc,
 	// the objects will be split into separate inline objects. In other words,
@@ -71,11 +72,17 @@ type ComponentBuilder struct {
 	// it should be representable as either YAML or JSON.
 	ObjectFiles []File `json:"objectFiles,omitempty"`
 
-	// Raw files represent arbitrary string data. Unlike object files,
+	// RawTextFiles files represent arbitrary string data. Unlike object files,
 	// these files don't need to be parsable as YAML or JSON. So, during the
 	// inline process, the data is inserted into a generated config map before
 	// being added to the objects. A ConfigMap is generated per-filegroup.
 	RawTextFiles []FileGroup `json:"rawTextFiles,omitempty"`
+
+	// Objects are object-files that are already inlined in the component. These
+	// are largely passed through to the built Component object, except for some
+	// built-in Builder types (ObjectTemplateBuilder, for example), that will be
+	// processed during the build process.
+	Objects []*unstructured.Unstructured `json:"objects,omitempty"`
 }
 
 // FileGroup represents a collection of files. When used to create ConfigMaps

--- a/pkg/build/inline_test.go
+++ b/pkg/build/inline_test.go
@@ -640,11 +640,11 @@ metadata:
 			},
 		},
 		{
-			desc:            "success: component, object template builder: already inlined",
+			desc:            "success: component, object template builder: already inlined; dir",
 			pathToComponent: "/component",
 			data: `
 kind: ComponentBuilder
-componentName: binary-blob
+componentName: tmpl-builder
 version: 1.2.3
 objects:
 - kind: ObjectTemplateBuilder
@@ -665,9 +665,52 @@ metadata:
 `),
 			},
 			expComp: compRef{
-				name: "binary-blob-1.2.3",
+				name: "tmpl-builder-1.2.3",
 				ref: bundle.ComponentReference{
-					ComponentName: "binary-blob",
+					ComponentName: "tmpl-builder",
+					Version:       "1.2.3",
+				},
+				obj: []objCheck{
+					{
+						name: "obj-tmpl",
+						subStrings: []string{
+							"name: {{.foo}}",
+							"type: string",
+							"type: go-template",
+						},
+					},
+				},
+			},
+		},
+		{
+			desc:            "success: component, object template builder: already inlined",
+			pathToComponent: "/foof/component.yaml",
+			data: `
+kind: ComponentBuilder
+componentName: tmpl-builder
+version: 1.2.3
+objects:
+- kind: ObjectTemplateBuilder
+  metadata:
+    name: obj-tmpl
+  file:
+    url: 'manifest/tmpl.yaml'
+  optionsSchema:
+    properties:
+      foo:
+        type: string
+`,
+			files: map[string][]byte{
+				"/foof/manifest/tmpl.yaml": []byte(`
+kind: pod
+metadata:
+  name: {{.foo}}
+`),
+			},
+			expComp: compRef{
+				name: "tmpl-builder-1.2.3",
+				ref: bundle.ComponentReference{
+					ComponentName: "tmpl-builder",
 					Version:       "1.2.3",
 				},
 				obj: []objCheck{

--- a/pkg/build/inline_test.go
+++ b/pkg/build/inline_test.go
@@ -639,6 +639,49 @@ metadata:
 				},
 			},
 		},
+		{
+			desc:            "success: component, object template builder: already inlined",
+			pathToComponent: "/component",
+			data: `
+kind: ComponentBuilder
+componentName: binary-blob
+version: 1.2.3
+objects:
+- kind: ObjectTemplateBuilder
+  metadata:
+    name: obj-tmpl
+  file:
+    url: 'manifest/tmpl.yaml'
+  optionsSchema:
+    properties:
+      foo:
+        type: string
+`,
+			files: map[string][]byte{
+				"/component/manifest/tmpl.yaml": []byte(`
+kind: pod
+metadata:
+  name: {{.foo}}
+`),
+			},
+			expComp: compRef{
+				name: "binary-blob-1.2.3",
+				ref: bundle.ComponentReference{
+					ComponentName: "binary-blob",
+					Version:       "1.2.3",
+				},
+				obj: []objCheck{
+					{
+						name: "obj-tmpl",
+						subStrings: []string{
+							"name: {{.foo}}",
+							"type: string",
+							"type: go-template",
+						},
+					},
+				},
+			},
+		},
 
 		// Error cases.
 		{

--- a/pkg/build/path_rewriter.go
+++ b/pkg/build/path_rewriter.go
@@ -33,10 +33,15 @@ func makeAbsWithParent(parent, obj *url.URL) *url.URL {
 	if path.IsAbs(obj.Path) {
 		return obj
 	}
+	parentDir := path.Dir(parent.Path)
+	if path.Ext(parent.Path) == "" {
+		// No extension: assume we've been passed a directory.
+		parentDir = parent.Path
+	}
 	return &url.URL{
 		Scheme: parent.Scheme,
 		Host:   parent.Host,
-		Path:   path.Clean(path.Join(path.Dir(parent.Path), obj.Path)),
+		Path:   path.Clean(path.Join(parentDir, obj.Path)),
 	}
 }
 


### PR DESCRIPTION
This PR adds support for component files + components in the component builders. This is nice for just inlining small objects that don't change often. In particular, this is useful for Requirements objects,  ObjectTemplateBuilders, and small PatchTemplates