### PR TITLE
Enable object deserialization test in component testsuite.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3,8 +3,11 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "io_bazel_rules_go",
-    urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.18.3/rules_go-0.18.3.tar.gz"],
-    sha256 = "86ae934bd4c43b99893fc64be9d9fc684b81461581df7ea8fc291c816f5ee8c5",
+    urls = [
+        "https://storage.googleapis.com/bazel-mirror/github.com/bazelbuild/rules_go/releases/download/0.18.6/rules_go-0.18.6.tar.gz",
+        "https://github.com/bazelbuild/rules_go/releases/download/0.18.6/rules_go-0.18.6.tar.gz",
+    ],
+    sha256 = "f04d2373bcaf8aa09bccb08a98a57e721306c8f6043a2a0ee610fd6853dcde3d",
 )
 
 http_archive(

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -8,6 +8,7 @@ filegroup(
         "//examples/jsonnet:testdata",
         "//examples/patchbuilder:testdata",
     ],
+    testonly = True,
     visibility = ["//visibility:public"],
 )
 

--- a/examples/cluster/BUILD.bazel
+++ b/examples/cluster/BUILD.bazel
@@ -4,5 +4,6 @@ filegroup(
         "**/*.yaml",
         "**/*.txt",
     ]),
+    testonly = True,
     visibility = ["//visibility:public"],
 )

--- a/examples/component/BUILD.bazel
+++ b/examples/component/BUILD.bazel
@@ -6,6 +6,7 @@ filegroup(
         "**/*.yaml",
         "**/*.txt",
     ]),
+    testonly = True,
     visibility = ["//visibility:public"],
 )
 

--- a/examples/component/test-suite.yaml
+++ b/examples/component/test-suite.yaml
@@ -1,6 +1,16 @@
 componentFile: etcd-component-builder.yaml
 
 testCases:
+- description: Deserialize Objects
+  build:
+    options:
+      ImageTag: '2.0'
+  apply:
+    options:
+      namespace: default
+  expect:
+    canKubeDeserialize: true
+
 - description: Success
   apply:
     options:

--- a/examples/jsonnet/BUILD.bazel
+++ b/examples/jsonnet/BUILD.bazel
@@ -21,6 +21,12 @@ filegroup(
 
 go_test(
     name = "go_default_test",
-    srcs = ["bazel_init_test.go"],
-    deps = ["//pkg/testutil:go_default_library"],
+    srcs = [
+        "bazel_init_test.go",
+        "jsonnet_test.go",
+    ],
+    deps = [
+        "//pkg/testutil:go_default_library",
+        "//pkg/testutil/componentsuite:go_default_library",
+    ],
 )

--- a/examples/jsonnet/BUILD.bazel
+++ b/examples/jsonnet/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_test")
+
 package(default_visibility = ["//visibility:private"])
 
 filegroup(
@@ -15,4 +17,10 @@ filegroup(
         "//pkg/options/jsonnet:__subpackages__",
         "//examples:__pkg__",
     ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["bazel_init_test.go"],
+    deps = ["//pkg/testutil:go_default_library"],
 )

--- a/examples/jsonnet/BUILD.bazel
+++ b/examples/jsonnet/BUILD.bazel
@@ -4,15 +4,7 @@ package(default_visibility = ["//visibility:private"])
 
 filegroup(
     name = "testdata",
-    srcs = [
-        "builder.yaml",
-        "multi-pods.builder.yaml",
-        "multi-pods.jsonnet",
-        "pod.builder.yaml",
-        "pod.jsonnet",
-        "pod-with-imports.builder.yaml",
-        "pod-with-imports.jsonnet",
-    ],
+    srcs = glob(["*.yaml", "*.jsonnet"]),
     visibility = [
         "//pkg/options/jsonnet:__subpackages__",
         "//examples:__pkg__",
@@ -25,6 +17,7 @@ go_test(
         "bazel_init_test.go",
         "jsonnet_test.go",
     ],
+    data = [":testdata"],
     deps = [
         "//pkg/testutil:go_default_library",
         "//pkg/testutil/componentsuite:go_default_library",

--- a/examples/jsonnet/BUILD.bazel
+++ b/examples/jsonnet/BUILD.bazel
@@ -4,7 +4,11 @@ package(default_visibility = ["//visibility:private"])
 
 filegroup(
     name = "testdata",
-    srcs = glob(["*.yaml", "*.jsonnet"]),
+    srcs = glob([
+        "*.yaml",
+        "*.jsonnet",
+    ]),
+    testonly = True,
     visibility = [
         "//pkg/options/jsonnet:__subpackages__",
         "//examples:__pkg__",

--- a/examples/jsonnet/bazel_init_test.go
+++ b/examples/jsonnet/bazel_init_test.go
@@ -1,0 +1,23 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package jsonnet_test
+
+import (
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/testutil"
+)
+
+func init() {
+	testutil.ChangeToBazelDir("examples/jsonnet")
+}

--- a/examples/jsonnet/builder.yaml
+++ b/examples/jsonnet/builder.yaml
@@ -5,4 +5,5 @@ version: 11.0.0
 objectFiles:
 - url: ./pod.builder.yaml
 - url: ./multi-pods.builder.yaml
-- url: ./pod-with-imports.builder.yaml
+# imports are not yet supported
+# - url: ./pod-with-imports.builder.yaml

--- a/examples/jsonnet/jsonnet_test.go
+++ b/examples/jsonnet/jsonnet_test.go
@@ -1,0 +1,25 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package jsonnet_test
+
+import (
+	"testing"
+
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/testutil/componentsuite"
+)
+
+func TestComponentSuite(t *testing.T) {
+	componentsuite.Run(t, "test-suite.yaml")
+}

--- a/examples/jsonnet/test-suite.yaml
+++ b/examples/jsonnet/test-suite.yaml
@@ -1,0 +1,47 @@
+componentFile: builder.yaml
+
+testCases:
+- description: Deserialize Objects
+  apply:
+    options:
+      DNSPolicy: default
+      ContainerImage: gcr.io/foof/foof:1.0
+  expect:
+    canKubeDeserialize: true
+
+- description: single-pod
+  apply:
+    options:
+      DNSPolicy: default-policy
+      ContainerImage: gcr.io/foof/foof:1.0
+  expect:
+    objects:
+    - kind: Pod
+      name: logger-pod
+      findSubstrs:
+      - 'dnsPolicy: default-policy'
+      - 'image: gcr.io/foof/foof:1.0'
+      - "name: logger"
+
+- description: Multi-pods
+  apply:
+    options:
+      DNSPolicy: default-policy
+      ContainerImage: gcr.io/foof/foof:1.0
+  expect:
+    objects:
+    - kind: Pod
+      name: pod1
+      findSubstrs:
+      - 'dnsPolicy: default-policy'
+      - 'image: gcr.io/foof/foof:1.0'
+    - kind: Pod
+      name: pod2
+      findSubstrs:
+      - 'dnsPolicy: default-policy'
+      - 'image: gcr.io/foof/foof:1.0'
+    - kind: Pod
+      name: pod3
+      findSubstrs:
+      - 'dnsPolicy: default-policy'
+      - 'image: gcr.io/foof/foof:1.0'

--- a/examples/patchbuilder/BUILD.bazel
+++ b/examples/patchbuilder/BUILD.bazel
@@ -3,9 +3,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_test")
 filegroup(
     name = "testdata",
     srcs = glob([
-        "**/*.yaml",
-        "**/*.txt",
+        "*.yaml",
+        "*.txt",
     ]),
+    testonly = True,
     visibility = ["//visibility:public"],
 )
 

--- a/examples/patchbuilder/test-suite.yaml
+++ b/examples/patchbuilder/test-suite.yaml
@@ -1,6 +1,16 @@
 componentFile: builder.yaml
-rootDirectory: './'
+
 testCases:
+- description: Deserialize Objects
+  build:
+    options:
+      ImageTag: '2.0'
+  apply:
+    options:
+      Namespace: default
+  expect:
+    canKubeDeserialize: true
+
 - description: Success
   build:
     options:

--- a/pkg/commands/cmdrunner/BUILD.bazel
+++ b/pkg/commands/cmdrunner/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = ["execute_cmd.go"],
     importpath = "github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/commands/cmdrunner",
     visibility = ["//visibility:public"],
+    testonly = True,
     deps = [
         "//pkg/commands:go_default_library",
         "//pkg/commands/cmdlib:go_default_library",

--- a/pkg/commands/cmdtest/BUILD.bazel
+++ b/pkg/commands/cmdtest/BUILD.bazel
@@ -2,6 +2,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
+    testonly = True,
     srcs = [
         "fake_cmd_io.go",
         "fake_exiter.go",

--- a/pkg/options/common.go
+++ b/pkg/options/common.go
@@ -30,7 +30,7 @@ func ApplyCommon(ref bundle.ComponentReference, objs []*unstructured.Unstructure
 	for _, obj := range objs {
 		outObjects, err := objFn(obj, ref, opts)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Sprintf("for component %v, error in applying: %v", ref, err)
 		}
 		newObj = append(newObj, outObjects...)
 	}

--- a/pkg/options/common.go
+++ b/pkg/options/common.go
@@ -15,6 +15,8 @@
 package options
 
 import (
+	"fmt"
+
 	bundle "github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/apis/bundle/v1alpha1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
@@ -30,7 +32,7 @@ func ApplyCommon(ref bundle.ComponentReference, objs []*unstructured.Unstructure
 	for _, obj := range objs {
 		outObjects, err := objFn(obj, ref, opts)
 		if err != nil {
-			return nil, fmt.Sprintf("for component %v, error in applying: %v", ref, err)
+			return nil, fmt.Errorf("for component %v, error in applying: %v", ref, err)
 		}
 		newObj = append(newObj, outObjects...)
 	}

--- a/pkg/options/gotmpl/go_template_applier.go
+++ b/pkg/options/gotmpl/go_template_applier.go
@@ -87,13 +87,13 @@ func applyOptions(obj *unstructured.Unstructured, ref bundle.ComponentReference,
 
 	tmpl, err := template.New(ref.ComponentName + "-" + obj.GetName() + "-tmpl").Parse(objTmpl.Template)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing template for object %q in component %v: %v", obj.GetName(), ref, err)
+		return nil, fmt.Errorf("error parsing template for object %q: %v", obj.GetName(), err)
 	}
 
 	var buf bytes.Buffer
 	err = tmpl.Execute(&buf, opts)
 	if err != nil {
-		return nil, fmt.Errorf("error executing template for component %v: %v", ref, err)
+		return nil, fmt.Errorf("error executing template for object %v: %v", obj.GetName(), err)
 	}
 
 	// TODO(kashomon): It would be better to use YAML-stream decoding, as can be

--- a/pkg/options/multi/BUILD.bazel
+++ b/pkg/options/multi/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "//pkg/apis/bundle/v1alpha1:go_default_library",
         "//pkg/options:go_default_library",
         "//pkg/options/gotmpl:go_default_library",
+        "//pkg/options/jsonnet:go_default_library",
         "//pkg/options/patchtmpl:go_default_library",
     ],
 )

--- a/pkg/options/multi/multi.go
+++ b/pkg/options/multi/multi.go
@@ -20,6 +20,7 @@ import (
 	bundle "github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/apis/bundle/v1alpha1"
 	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/options"
 	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/options/gotmpl"
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/options/jsonnet"
 	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/options/patchtmpl"
 )
 
@@ -37,6 +38,7 @@ func NewDefaultApplier() options.Applier {
 	return NewApplier([]options.Applier{
 		gotmpl.NewApplier(),
 		patchtmpl.NewDefaultApplier(),
+		jsonnet.NewApplier(nil /* importer */),
 	})
 }
 

--- a/pkg/options/multi/multi.go
+++ b/pkg/options/multi/multi.go
@@ -37,8 +37,8 @@ func NewApplier(appliers []options.Applier) options.Applier {
 func NewDefaultApplier() options.Applier {
 	return NewApplier([]options.Applier{
 		gotmpl.NewApplier(),
-		patchtmpl.NewDefaultApplier(),
 		jsonnet.NewApplier(nil /* importer */),
+		patchtmpl.NewDefaultApplier(),
 	})
 }
 

--- a/pkg/options/patchtmpl/scheme.go
+++ b/pkg/options/patchtmpl/scheme.go
@@ -15,6 +15,7 @@
 package patchtmpl
 
 import (
+	bundle "github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/apis/bundle/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	appsv1beta1 "k8s.io/api/apps/v1beta1"
 	appsv1beta2 "k8s.io/api/apps/v1beta2"
@@ -50,6 +51,7 @@ func init() {
 	must(policyv1beta1.AddToScheme(k.KubeScheme))
 	must(rbacv1.AddToScheme(k.KubeScheme))
 	must(storagev1.AddToScheme(k.KubeScheme))
+	must(bundle.AddToScheme(k.KubeScheme))
 
 	defaultPatcherScheme = k
 }

--- a/pkg/testutil/BUILD.bazel
+++ b/pkg/testutil/BUILD.bazel
@@ -2,6 +2,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
+    testonly = True,
     srcs = [
         "errors.go",
         "fake_reader_writer.go",

--- a/pkg/testutil/componentsuite/BUILD.bazel
+++ b/pkg/testutil/componentsuite/BUILD.bazel
@@ -2,6 +2,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
+    testonly = True,
     srcs = [
         "componentsuite.go",
         "schema.go",
@@ -27,6 +28,7 @@ go_library(
 
 go_test(
     name = "go_default_test",
+    testonly = True,
     srcs = [
         "bazel_init_test.go",
         "componentsuite_test.go",

--- a/pkg/testutil/componentsuite/BUILD.bazel
+++ b/pkg/testutil/componentsuite/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "componentsuite.go",
         "schema.go",
+        "validate.go",
     ],
     importpath = "github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/testutil/componentsuite",
     visibility = ["//visibility:public"],
@@ -14,10 +15,13 @@ go_library(
         "//pkg/converter:go_default_library",
         "//pkg/filter:go_default_library",
         "//pkg/options:go_default_library",
+        "//pkg/options/multi:go_default_library",
         "//pkg/options/patchtmpl:go_default_library",
         "//pkg/testutil:go_default_library",
         "//pkg/validate:go_default_library",
         "//pkg/wrapper:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
     ],
 )
 

--- a/pkg/testutil/componentsuite/componentsuite.go
+++ b/pkg/testutil/componentsuite/componentsuite.go
@@ -124,9 +124,6 @@ func runBuild(t *testing.T, comp *bundle.Component, tc *TestCase) *bundle.Compon
 }
 
 func runApply(t *testing.T, comp *bundle.Component, tc *TestCase) *bundle.Component {
-	applyOpts := &filter.Options{}
-	applyOpts.Annotations = tc.Apply.Filters
-
 	applier := multi.NewDefaultApplier()
 
 	comp, err := applier.ApplyOptions(comp, tc.Apply.Options)

--- a/pkg/testutil/componentsuite/componentsuite.go
+++ b/pkg/testutil/componentsuite/componentsuite.go
@@ -17,20 +17,17 @@ package componentsuite
 
 import (
 	"context"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	bundle "github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/apis/bundle/v1alpha1"
 	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/build"
 	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/converter"
 	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/filter"
-	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/options/patchtmpl"
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/options/multi"
 	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/testutil"
-	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/validate"
 	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/wrapper"
 )
 
@@ -130,88 +127,20 @@ func runApply(t *testing.T, comp *bundle.Component, tc *TestCase) *bundle.Compon
 	applyOpts := &filter.Options{}
 	applyOpts.Annotations = tc.Apply.Filters
 
-	applier := patchtmpl.NewApplier(
-		patchtmpl.DefaultPatcherScheme(),
-		applyOpts,
-		true /* includeTemplates, for debugging */)
+	applier := multi.NewDefaultApplier()
 
 	comp, err := applier.ApplyOptions(comp, tc.Apply.Options)
 	cerr := testutil.CheckErrorCases(err, tc.Expect.ApplyErrSubstr)
 	if cerr != nil {
 		t.Fatal(cerr)
 	}
+
+	o, _ := converter.FromObject(comp).ToYAMLString()
+	t.Logf("obj: %v", o)
+
 	if err != nil {
 		// Since there's an error, it's a terminal condition
 		return nil
 	}
 	return comp
-}
-
-type objKey struct {
-	name string
-	kind string
-}
-
-func (ok objKey) String() string {
-	return fmt.Sprintf("{name: %q, kind: %q}", ok.name, ok.kind)
-}
-
-func runValidate(t *testing.T, comp *bundle.Component, tc *TestCase) {
-	if errList := validate.Component(comp); len(errList) > 0 {
-		t.Errorf("There were errors validating component:\n%v", errList.ToAggregate())
-	}
-
-	objCheckMap := make(map[objKey]ObjectCheck)
-	for _, oc := range tc.Expect.Objects {
-		objCheckMap[objKey{
-			name: oc.Name,
-			kind: oc.Kind,
-		}] = oc
-	}
-
-	objMap := make(map[objKey]string)
-	for _, obj := range comp.Spec.Objects {
-		matchFail := false
-
-		key := objKey{name: obj.GetName(), kind: obj.GetKind()}
-		objStr, err := converter.FromObject(obj).ToYAMLString()
-		if err != nil {
-			// This is a very unlikely error.
-			t.Fatal(err)
-		}
-		objMap[key] = objStr
-
-		check := objCheckMap[key]
-		for _, expStr := range check.FindSubstrs {
-			if !strings.Contains(objStr, expStr) {
-				t.Errorf("Did not find %q in object %v, but expected to", expStr, key)
-				matchFail = true
-			}
-		}
-
-		for _, noExpStr := range check.NotFindSubstrs {
-			if strings.Contains(objStr, noExpStr) {
-				t.Errorf("Found %q in object %v, but did not expect to", noExpStr, key)
-				matchFail = true
-			}
-		}
-
-		if matchFail {
-			t.Errorf("Contents for object that didn't meet expectations %v:\n%s", key, objStr)
-		}
-	}
-
-	for key := range objCheckMap {
-		if _, ok := objMap[key]; !ok {
-			t.Errorf("Got object-keys %q, but expected to find object %v", stringMapKeys(objMap), key)
-		}
-	}
-}
-
-func stringMapKeys(m map[objKey]string) []string {
-	var out []string
-	for k := range m {
-		out = append(out, k.String())
-	}
-	return out
 }

--- a/pkg/testutil/componentsuite/componentsuite.go
+++ b/pkg/testutil/componentsuite/componentsuite.go
@@ -134,12 +134,9 @@ func runApply(t *testing.T, comp *bundle.Component, tc *TestCase) *bundle.Compon
 	if cerr != nil {
 		t.Fatal(cerr)
 	}
-
-	o, _ := converter.FromObject(comp).ToYAMLString()
-	t.Logf("obj: %v", o)
-
 	if err != nil {
-		// Since there's an error, it's a terminal condition
+		// Since there's an error, it's a terminal condition. We've already checked
+		// that the err is as expected in CheckErrorCases.
 		return nil
 	}
 	return comp

--- a/pkg/testutil/componentsuite/schema.go
+++ b/pkg/testutil/componentsuite/schema.go
@@ -74,6 +74,10 @@ type Expect struct {
 	// Objects contains expectations for objects.
 	Objects []ObjectCheck `json:"objects"`
 
+	// CanKubeDeserialize ensures that all objects can be deserialized as
+	// concrete Kubernetes objects, using the built in schema.
+	CanKubeDeserialize bool `json:"CanKubeDeserialize"`
+
 	// BuildErrSubstr indicates a substring that's expected to be in an error in
 	// the build-process.
 	BuildErrSubstr string `json:"buildErrSubstr"`

--- a/pkg/testutil/componentsuite/schema.go
+++ b/pkg/testutil/componentsuite/schema.go
@@ -53,20 +53,12 @@ type TestCase struct {
 type Build struct {
 	// Options for the PatchTemplate build process
 	Options options.JSONOptions `json:"options"`
-
-	// Filters selects which patches to apply, based on the
-	// annotations on the patches.
-	Filters map[string]string `json:"filters"`
 }
 
 // Apply contains build paramaters
 type Apply struct {
 	// Options for apply process
 	Options options.JSONOptions `json:"options"`
-
-	// Filters selects which patches to apply, based on the
-	// annotations on the patches.
-	Filters map[string]string `json:"filters"`
 }
 
 // Expect contains expectations that should be filled.

--- a/pkg/testutil/componentsuite/validate.go
+++ b/pkg/testutil/componentsuite/validate.go
@@ -1,0 +1,137 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package componentsuite
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	bundle "github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/apis/bundle/v1alpha1"
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/converter"
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/options/patchtmpl"
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/validate"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+type objKey struct {
+	name string
+	kind string
+}
+
+// String returns the stringified objKey.
+func (o objKey) String() string {
+	return fmt.Sprintf("{name: %s, kind: %s}", o.name, o.kind)
+}
+
+func objKeyFromObjCheck(oc ObjectCheck) objKey {
+	return objKey{
+		name: oc.Name,
+		kind: oc.Kind,
+	}
+}
+
+func objKeyFromObj(oc *unstructured.Unstructured) objKey {
+	return objKey{
+		name: oc.GetName(),
+		kind: oc.GetKind(),
+	}
+}
+
+func runValidate(t *testing.T, comp *bundle.Component, tc *TestCase) {
+	if errList := validate.Component(comp); len(errList) > 0 {
+		t.Errorf("There were errors validating component:\n%v", errList.ToAggregate())
+	}
+
+	if tc.Expect.CanKubeDeserialize {
+		checkObjectsDeserialize(t, comp)
+	}
+
+	checkObjectProperties(t, comp, tc)
+}
+
+func checkObjectsDeserialize(t *testing.T, comp *bundle.Component) {
+	scheme := patchtmpl.DefaultPatcherScheme()
+	deserializer := scheme.Codecs.UniversalDeserializer()
+
+	for _, obj := range comp.Spec.Objects {
+		key := objKeyFromObj(obj)
+		objByt, err := converter.FromObject(obj).ToJSON()
+		if err != nil {
+			// This would be pretty unlikely
+			t.Errorf("Error converting object %v to JSON: %v", key, err)
+			continue
+		}
+
+		_, err = runtime.Decode(deserializer, objByt)
+		if err != nil {
+			t.Errorf("Error decode object %v: %v", key, err)
+		}
+	}
+}
+
+func checkObjectProperties(t *testing.T, comp *bundle.Component, tc *TestCase) {
+	objCheckMap := make(map[objKey]ObjectCheck)
+	for _, oc := range tc.Expect.Objects {
+		objCheckMap[objKeyFromObjCheck(oc)] = oc
+	}
+
+	objMap := make(map[objKey]string)
+	for _, obj := range comp.Spec.Objects {
+		matchFail := false
+
+		key := objKeyFromObj(obj)
+		objStr, err := converter.FromObject(obj).ToYAMLString()
+		if err != nil {
+			// This is a very unlikely error.
+			t.Fatal(err)
+		}
+		objMap[key] = objStr
+
+		check := objCheckMap[key]
+		for _, expStr := range check.FindSubstrs {
+			if !strings.Contains(objStr, expStr) {
+				t.Errorf("Did not find %q in object %v, but expected to", expStr, key)
+				matchFail = true
+			}
+		}
+
+		for _, noExpStr := range check.NotFindSubstrs {
+			if strings.Contains(objStr, noExpStr) {
+				t.Errorf("Found %q in object %v, but did not expect to", noExpStr, key)
+				matchFail = true
+			}
+		}
+
+		if matchFail {
+			t.Logf("Contents for object that didn't meet expectations %v:\n%s", key, objStr)
+		}
+	}
+
+	for key := range objCheckMap {
+		if _, ok := objMap[key]; !ok {
+			t.Errorf("Got object-keys %q, but expected to find object %v", stringMapKeys(objMap), key)
+		}
+	}
+}
+
+func stringMapKeys(m map[objKey]string) []string {
+	var out []string
+	for k := range m {
+		out = append(out, k.String())
+	}
+	return out
+}


### PR DESCRIPTION
This PR modifies the component test-suite to have a canKubeDeserialize
field that checks whether objects can be deserialized using the internal
Kubernetes deserialization logic. This relies on the schema in the
patchtmpl (which perhaps should be put in a more common place, like
`pkg/options`)

A couple smaller changes:

- disable jsonnet importing example for now
- add jsonnet to the multi-applier
- add a deserialize test case to all examples
- add a test case for jsonnet