### PR TITLE
Preserve PatchType when creating PatchTemplate from builder

### DIFF
--- a/pkg/build/patchbuild.go
+++ b/pkg/build/patchbuild.go
@@ -70,6 +70,7 @@ func PatchTemplate(ptb *bundle.PatchTemplateBuilder, opts options.JSONOptions) (
 			APIVersion: "bundle.gke.io/v1alpha1",
 			Kind:       "PatchTemplate",
 		},
+		PatchType:     ptb.PatchType,
 		ObjectMeta:    *ptb.ObjectMeta.DeepCopy(),
 		OptionsSchema: ptb.TargetSchema.DeepCopy(),
 		Template:      buf.String(),

--- a/pkg/build/patchbuild_test.go
+++ b/pkg/build/patchbuild_test.go
@@ -84,6 +84,41 @@ spec:
 `,
 		},
 		{
+			desc: "success: patch, no options, patchType: JSONPatch",
+			component: `
+kind: Component
+spec:
+  objects:
+  - apiVersion: v1
+    kind: MyCustomResource
+  - kind: PatchTemplateBuilder
+    apiVersion: bundle.gke.io/v1alpha1
+    patchType: JSONPatch
+    template: |
+      kind: MyCustomResource
+      metadata:
+        namespace: foo
+`,
+			output: `
+kind: Component
+metadata:
+  creationTimestamp: null
+spec:
+  objects:
+  - apiVersion: v1
+    kind: MyCustomResource
+  - apiVersion: bundle.gke.io/v1alpha1
+    kind: PatchTemplate
+    metadata:
+      creationTimestamp: null
+    patchType: JSONPatch
+    template: |
+      kind: MyCustomResource
+      metadata:
+        namespace: foo
+`,
+		},
+		{
 			desc: "success: patch, build options, no schema",
 			opts: map[string]interface{}{
 				"Namespace": "foo",


### PR DESCRIPTION
In trying to use JSONPatch with a PatchTemplateBuilder, I noticed that the PatchType field was not getting carried through to the created PatchTemplate. This change addresses that.

I also added a testcase (which previously failed).