### PR TITLE
gotmpl Applier: Add text/template options config

### DIFF
--- a/pkg/options/patchtmpl/patch_benchmark_test.go
+++ b/pkg/options/patchtmpl/patch_benchmark_test.go
@@ -52,7 +52,7 @@ spec:
 	}
 
 	for i := 0; i < t.N; i++ {
-		patcher := NewApplier(DefaultPatcherScheme(), customFilter, true)
+		patcher := NewApplierWithConfig(WithFilterOpts(customFilter), WithIncludeTemplates(true))
 		compObj, err := converter.FromYAMLString(component).ToComponent()
 		if err != nil {
 			t.Fatal(err)

--- a/pkg/options/patchtmpl/patch_test.go
+++ b/pkg/options/patchtmpl/patch_test.go
@@ -558,7 +558,7 @@ spec:
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			patcher := NewApplier(DefaultPatcherScheme(), tc.customFilter, !tc.removeTemplates)
+			patcher := NewApplierWithConfig(WithFilterOpts(tc.customFilter), WithIncludeTemplates(!tc.removeTemplates))
 
 			compObj, err := converter.FromYAMLString(tc.component).ToComponent()
 			if err != nil {


### PR DESCRIPTION
This commit lets the caller specify text/template options when creating a gotmpl applier.  The only meaningful option to pass is `missingkey={ignore,error,zero}`, to control the behavior when the template references an unset variable.