### PR TITLE
Add storage/v1beta1 to default patcher

### DIFF
--- a/pkg/options/patchtmpl/BUILD.bazel
+++ b/pkg/options/patchtmpl/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "@io_k8s_api//policy/v1beta1:go_default_library",
         "@io_k8s_api//rbac/v1:go_default_library",
         "@io_k8s_api//storage/v1:go_default_library",
+        "@io_k8s_api//storage/v1beta1:go_default_library",
         "@io_k8s_apiextensions_apiserver//pkg/apis/apiextensions/v1beta1:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1/unstructured:go_default_library",
         "@io_k8s_apimachinery//pkg/runtime:go_default_library",

--- a/pkg/options/patchtmpl/scheme.go
+++ b/pkg/options/patchtmpl/scheme.go
@@ -24,6 +24,7 @@ import (
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	storagev1 "k8s.io/api/storage/v1"
+	storagev1beta1 "k8s.io/api/storage/v1beta1"
 	crdext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
@@ -51,6 +52,7 @@ func init() {
 	must(policyv1beta1.AddToScheme(k.KubeScheme))
 	must(rbacv1.AddToScheme(k.KubeScheme))
 	must(storagev1.AddToScheme(k.KubeScheme))
+	must(storagev1beta1.AddToScheme(k.KubeScheme))
 	must(bundle.AddToScheme(k.KubeScheme))
 
 	defaultPatcherScheme = k


### PR DESCRIPTION
This change allows clients to patch CSIDriver and CSINode objects in
cluster bundles. These types were added to v1beta1 in kubernetes 1.14.0.

Tested: bazel test //...