### PR TITLE
Add webhook v1beta1 to default patcher

### DIFF
--- a/pkg/options/patchtmpl/BUILD.bazel
+++ b/pkg/options/patchtmpl/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "//pkg/options:go_default_library",
         "//pkg/options/openapi:go_default_library",
         "@com_github_evanphx_json_patch//:go_default_library",
+        "@io_k8s_api//admissionregistration/v1beta1:go_default_library",
         "@io_k8s_api//apps/v1:go_default_library",
         "@io_k8s_api//apps/v1beta1:go_default_library",
         "@io_k8s_api//apps/v1beta2:go_default_library",

--- a/pkg/options/patchtmpl/scheme.go
+++ b/pkg/options/patchtmpl/scheme.go
@@ -16,6 +16,7 @@ package patchtmpl
 
 import (
 	bundle "github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/apis/bundle/v1alpha1"
+	webhookv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
 	appsv1beta1 "k8s.io/api/apps/v1beta1"
 	appsv1beta2 "k8s.io/api/apps/v1beta2"
@@ -25,7 +26,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	storagev1beta1 "k8s.io/api/storage/v1beta1"
-	crdext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	crdextv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 )
@@ -47,12 +48,13 @@ func init() {
 	must(appsv1beta1.AddToScheme(k.KubeScheme))
 	must(appsv1beta2.AddToScheme(k.KubeScheme))
 	must(corev1.AddToScheme(k.KubeScheme))
-	must(crdext.AddToScheme(k.KubeScheme))
+	must(crdextv1beta1.AddToScheme(k.KubeScheme))
 	must(extv1beta1.AddToScheme(k.KubeScheme))
 	must(policyv1beta1.AddToScheme(k.KubeScheme))
 	must(rbacv1.AddToScheme(k.KubeScheme))
 	must(storagev1.AddToScheme(k.KubeScheme))
 	must(storagev1beta1.AddToScheme(k.KubeScheme))
+	must(webhookv1beta1.AddToScheme(k.KubeScheme))
 	must(bundle.AddToScheme(k.KubeScheme))
 
 	defaultPatcherScheme = k


### PR DESCRIPTION
This change allows clients to patch webhook objects in cluster bundles. `admissionregistration.k8s.io/v1beta1` is available since kubernetes 1.9