### PR TITLE
Add a TemplateBuilder example.

### DIFF
--- a/examples/templatebuilder/BUILD.bazel
+++ b/examples/templatebuilder/BUILD.bazel
@@ -2,12 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_test")
 
 filegroup(
     name = "testdata",
-    srcs = [
-        "//examples/cluster:testdata",
-        "//examples/component:testdata",
-        "//examples/patchbuilder:testdata",
-        "//examples/templatebuilder:testdata",
-    ],
+    srcs = glob([
+        "*.yaml",
+        "*.txt",
+    ]),
     testonly = True,
     visibility = ["//visibility:public"],
 )
@@ -16,7 +14,7 @@ go_test(
     name = "go_default_test",
     srcs = [
         "bazel_init_test.go",
-        "examples_test.go",
+        "component_test.go",
     ],
     data = [":testdata"],
     deps = [

--- a/examples/templatebuilder/README.md
+++ b/examples/templatebuilder/README.md
@@ -1,0 +1,4 @@
+# Go-template Component Example
+
+This component example is similar to the component example in ../component,
+except that here we use go-templates rather than patch templates.

--- a/examples/templatebuilder/bazel_init_test.go
+++ b/examples/templatebuilder/bazel_init_test.go
@@ -1,0 +1,23 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package templatebuilder_test
+
+import (
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/testutil"
+)
+
+func init() {
+	testutil.ChangeToBazelDir("examples/templatebuilder")
+}

--- a/examples/templatebuilder/builder.yaml
+++ b/examples/templatebuilder/builder.yaml
@@ -1,0 +1,20 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: bundle.gke.io/v1alpha1
+kind: ComponentBuilder
+componentName: etcd-component
+version: 30.0.2
+objectFiles:
+- url: template-builder.yaml

--- a/examples/templatebuilder/component_test.go
+++ b/examples/templatebuilder/component_test.go
@@ -1,0 +1,25 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package templatebuilder_test
+
+import (
+	"testing"
+
+	"github.com/GoogleCloudPlatform/k8s-cluster-bundle/pkg/testutil/componentsuite"
+)
+
+func TestComponentSuite(t *testing.T) {
+	componentsuite.Run(t, "test-suite.yaml")
+}

--- a/examples/templatebuilder/etcd-template.yaml
+++ b/examples/templatebuilder/etcd-template.yaml
@@ -1,0 +1,81 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: etcd-server
+  namespace: "{{.Namespace}}"
+spec:
+  containers:
+  - command:
+    - /bin/sh
+    - -c
+    - |
+      exec /usr/local/bin/etcd
+      --name etcd-server-primary
+      --listen-peer-urls $(LISTEN_PEER_URLS)
+      --initial-advertise-peer-urls $(INITIAL_ADVERTISE_PEER_URLS)
+      --advertise-client-urls $(CLIENT_URLS)
+      --listen-client-urls $(CLIENT_URLS)
+      --quota-backend-bytes=6442450944
+      --data-dir /var/etcd/data
+      --initial-cluster-state new
+      --initial-cluster etcd-server-primary=$(CLIENT_URLS)
+      1>>/var/log/etcd.log
+      2>&1
+    env:
+    - name: TARGET_STORAGE
+      value: etcd3
+    - name: TARGET_VERSION
+      value: 3.1.11
+    - name: DATA_DIRECTORY
+      value: /var/etcd/data
+    - name: INITIAL_CLUSTER
+      value: etcd-server-primary=http://10.1.1.1:2380
+    - name: LISTEN_PEER_URLS
+      value: http://10.1.1.1:2380
+    - name: INITIAL_ADVERTISE_PEER_URLS
+      value: http://10.1.1.1:2380
+    - name: CLIENT_URLS
+      value: http://127.0.0.1:2379
+    - name: ETCD_CREDS
+      value: ""
+    image: k8s.gcr.io/etcd:3.1.11
+    livenessProbe:
+      httpGet:
+        host: 127.0.0.1
+        path: /health
+        port: 2379
+      initialDelaySeconds: 15
+      timeoutSeconds: 15
+    name: etcd-container
+    ports:
+    - containerPort: 2380
+      hostPort: 2380
+      name: serverport
+    - containerPort: 2379
+      hostPort: 2379
+      name: clientport
+    resources:
+      requests:
+        cpu: 200m
+    volumeMounts:
+    - mountPath: /var/etcd
+      name: varetcd
+      readOnly: false
+    - mountPath: /var/log/etcd.log
+      name: varlogetcd
+      readOnly: false
+    - mountPath: /etc/srv/kubernetes
+      name: etc
+      readOnly: false
+  hostNetwork: true
+  volumes:
+  - hostPath:
+      path: /mnt/disks/master-pd/var/etcd
+    name: varetcd
+  - hostPath:
+      path: /var/log/etcd.log
+      type: FileOrCreate
+    name: varlogetcd
+  - hostPath:
+      path: /etc/srv/kubernetes
+    name: etc

--- a/examples/templatebuilder/template-builder.yaml
+++ b/examples/templatebuilder/template-builder.yaml
@@ -1,0 +1,4 @@
+apiVersion: bundle.gke.io/v1alpha1
+kind: ObjectTemplateBuilder
+file:
+  url: etcd-template.yaml

--- a/examples/templatebuilder/test-suite.yaml
+++ b/examples/templatebuilder/test-suite.yaml
@@ -1,0 +1,20 @@
+componentFile: builder.yaml
+
+testCases:
+- description: Deserialize Objects
+  apply:
+    options:
+      Namespace: default
+  expect:
+    canKubeDeserialize: true
+
+- description: Success
+  apply:
+    options:
+      Namespace: default-ns
+  expect:
+    objects:
+    - kind: Pod
+      name: etcd-server
+      findSubstrs:
+      - 'namespace: default-ns'


### PR DESCRIPTION
This PR adds a new (go) template builder example to the `examples/` directory.