### PR TITLE
Support invert match in the internal function `matches`.

### DIFF
--- a/pkg/filter/filter.go
+++ b/pkg/filter/filter.go
@@ -87,10 +87,7 @@ func OptionsFromObjectSelector(sel *bundle.ObjectSelector) *Options {
 // properties of the object-children of the components. This is the opposite
 // matching from SelectComponents.
 func (f *Filter) FilterComponents(data []*bundle.Component, o *Options) []*bundle.Component {
-	matched, notMatched := f.PartitionComponents(data, o)
-	if o.InvertMatch {
-		return matched
-	}
+	_, notMatched := f.PartitionComponents(data, o)
 	return notMatched
 }
 
@@ -100,10 +97,7 @@ func (f *Filter) FilterComponents(data []*bundle.Component, o *Options) []*bundl
 // object-children of the components. This performs the opposte matching from
 // FilterComponents.
 func (f *Filter) SelectComponents(data []*bundle.Component, o *Options) []*bundle.Component {
-	matched, notMatched := f.PartitionComponents(data, o)
-	if o.InvertMatch {
-		return notMatched
-	}
+	matched, _ := f.PartitionComponents(data, o)
 	return matched
 }
 
@@ -138,20 +132,14 @@ func (f *Filter) PartitionComponents(data []*bundle.Component, o *Options) ([]*b
 // FilterObjects removes objects based on the ObjectMeta properties of the objects,
 // returning a new list with just filtered objects. This performs the opposite match from SelectObjects.
 func (f *Filter) FilterObjects(data []*unstructured.Unstructured, o *Options) []*unstructured.Unstructured {
-	matched, notMatched := f.PartitionObjects(data, o)
-	if o.InvertMatch {
-		return matched
-	}
+	_, notMatched := f.PartitionObjects(data, o)
 	return notMatched
 }
 
 // SelectObjects picks objects based on the ObjectMeta properties of the objects,
 // returning a new list with just filtered objects.
 func (f *Filter) SelectObjects(data []*unstructured.Unstructured, o *Options) []*unstructured.Unstructured {
-	matched, notMatched := f.PartitionObjects(data, o)
-	if o.InvertMatch {
-		return notMatched
-	}
+	matched, _ := f.PartitionObjects(data, o)
 	return matched
 }
 
@@ -295,7 +283,12 @@ func matches(d *objectData, o *Options) bool {
 			}
 		}
 	}
-	return matchesKinds && matchesNS && matchesNames && matchesAnnot && matchesLabels
+
+	matches := matchesKinds && matchesNS && matchesNames && matchesAnnot && matchesLabels
+	if o.InvertMatch {
+		return !matches
+	}
+	return matches
 }
 
 // ComponentPredicate is a func that returns true for components that match


### PR DESCRIPTION
The invert match should be implemented in the underlying `matches` function, or else functions like `MatchesComponent` and `MatchesObject` won't have the support.

And please note that they are used by patch.go https://github.com/GoogleCloudPlatform/k8s-cluster-bundle/blob/master/pkg/options/patchtmpl/patch.go#L359