### PR TITLE
Ensure that the `selector` field of PatchTemplateBuilders gets copied…

### DIFF
--- a/pkg/build/patchbuild.go
+++ b/pkg/build/patchbuild.go
@@ -73,6 +73,7 @@ func PatchTemplate(ptb *bundle.PatchTemplateBuilder, opts options.JSONOptions) (
 		PatchType:     ptb.PatchType,
 		ObjectMeta:    *ptb.ObjectMeta.DeepCopy(),
 		OptionsSchema: ptb.TargetSchema.DeepCopy(),
+		Selector:      ptb.Selector.DeepCopy(),
 		Template:      buf.String(),
 	}
 	return pt, nil


### PR DESCRIPTION
… to the generated PatchTemplates.

Without this fix, the bundle build process unceremoniously drops the `selector` field that should appear in a PatchTemplate generated from a PatchTemplateBuilder.