### PR TITLE
Modify examples/patchbuilder/deployment-patch-builder.yaml to reproduce number comparison issue.

### DIFF
--- a/examples/patchbuilder/deployment-patch-builder.yaml
+++ b/examples/patchbuilder/deployment-patch-builder.yaml
@@ -34,5 +34,7 @@ template: |
         containers:
           - name: hello-app
             image: {{ .Registry }}/hello-app:{{ .ImageTag }}
+            {{if ge .Port 1}}
             ports:
             - containerPort: {{.Port}}
+            {{end}}


### PR DESCRIPTION
With the change, running `bazel test //examples/patchbuilder/...` failed with:
    --- FAIL: TestComponentSuite/Deserialize_Objects (0.00s)
        componentsuite.go:117: got error "cannot build PatchTemplate from PatchTemplateBuilder \"\": error executing template: template: ptb:12:15: executing \"ptb\" at <ge .Port 1>: error calling ge: incompatible types for comparison" but expected no error