### PR TITLE
Add test cases for patch template builder edgcase

### DIFF
--- a/examples/patchbuilder/deployment-patch-builder.yaml
+++ b/examples/patchbuilder/deployment-patch-builder.yaml
@@ -7,6 +7,14 @@ buildSchema:
     ImageTag:
       description: The image tag to deploy.
       type: string
+    PortStartGuard:
+      description: Start stanza for the port
+      type: string
+      default: "{{if ge .Port 1.0}}"
+    PortEndGuard:
+      description: End stanza for the port
+      type: string
+      default: "{{end}}"
 targetSchema:
   required:
     - Namespace
@@ -32,9 +40,9 @@ template: |
     template:
       spec:
         containers:
-          - name: hello-app
-            image: {{ .Registry }}/hello-app:{{ .ImageTag }}
-            {{if ge .Port 1}}
-            ports:
-            - containerPort: {{.Port}}
-            {{end}}
+        - name: hello-app
+          image: {{ .Registry }}/hello-app:{{ .ImageTag }}
+          {{ .PortStartGuard }}
+          ports:
+          - containerPort: {{ .Port }}
+          {{ .PortEndGuard }}

--- a/pkg/build/patchbuild.go
+++ b/pkg/build/patchbuild.go
@@ -36,7 +36,7 @@ func PatchTemplate(ptb *bundle.PatchTemplateBuilder, opts options.JSONOptions) (
 		return nil, fmt.Errorf("cannot build PatchTemplate from PatchTemplateBuilder %q: it has an empty template", name)
 	}
 
-	tmpl, err := template.New("ptb").Parse(ptb.Template)
+	tmpl, err := template.New("temporary-patch-template-builder").Parse(ptb.Template)
 	if err != nil {
 		return nil, fmt.Errorf("cannot build PatchTemplate from PatchTemplateBuilder %q: error parsing template: %v", name, err)
 	}

--- a/pkg/converter/converter_test.go
+++ b/pkg/converter/converter_test.go
@@ -15,6 +15,7 @@
 package converter
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -199,5 +200,35 @@ func TestConverterFormatTypeInversions(t *testing.T) {
 	}
 	if secondIttObj.APIVersion != "bundle.gke.io/v1alpha1" {
 		t.Fatalf("manifest apiVersion key doesn't match original one:expected=v1, got=%v", thirdIttObj.APIVersion)
+	}
+}
+
+type SomeObject struct {
+	String string
+	Float  float64
+	Int    int
+	Val    interface{}
+}
+
+func TestConvertInteger(t *testing.T) {
+	example := &SomeObject{
+		String: "foo",
+		Float:  1.123,
+		Int:    123,
+		Val:    123.0,
+	}
+	yamlEx := `
+String: foo
+Float: 1.123
+Int: 123
+Val: 123
+`
+	out := &SomeObject{}
+	err := FromYAMLString(yamlEx).ToObject(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(out, example) {
+		t.Errorf("Convert(%s)=%+v, but expected %+v", yamlEx, out, example)
 	}
 }

--- a/pkg/options/openapi/validate.go
+++ b/pkg/options/openapi/validate.go
@@ -58,8 +58,8 @@ func ValidateOptions(opts options.JSONOptions, optSchema *apiextv1beta1.JSONSche
 	openapiSchema := &spec.Schema{}
 	data, err := k8sOpenapiSchema.MarshalJSON()
 	if err != nil {
-                return nil, err
-        }
+		return nil, err
+	}
 	openapiSchema.UnmarshalJSON(data)
 
 	validator := validate.NewSchemaValidator(openapiSchema, nil, "", strfmt.Default)

--- a/pkg/options/patchtmpl/patch_test.go
+++ b/pkg/options/patchtmpl/patch_test.go
@@ -489,6 +489,39 @@ spec:
 			removeTemplates: true,
 		},
 
+		{
+			desc: "success: patch with numbers (floats)",
+			component: `
+kind: Component
+spec:
+  objects:
+  - apiVersion: v1
+    kind: Pod
+  - kind: PatchTemplate
+    optionsSchema:
+      properties:
+        Name:
+          type: string
+          default: zed
+        Port:
+          description: Container port for the helloweb app.
+          type: number
+          default: 8080
+    template: |
+      kind: Pod
+      metadata:
+        namespace: {{.Name}}
+      spec:
+        containers:
+          - name: hello-app
+            {{if ge .Port 1.0}}
+            ports:
+            - containerPort: {{.Port}}
+            {{end}}
+`,
+			expMatchSubstrs: []string{"containerPort: 8080"},
+		},
+
 		// Errors
 		{
 			desc: "fail: patch, basic options: missing variable",


### PR DESCRIPTION
Here, I added test cases for patch template builder edgecase.

There are two issues:

1. Mixing go-templates and patch template builders don't work terribly
   well. Because the patch template builder has built into a secondary
   template, any complex go-template properties need to be applied in
   the build phase.
2. The YAML/JSON conversion schema can't tell the difference between an
   integer and a float.

These are unfortunately limitations of the patch template design.

Here, I add a possible solution (put the go-template stuff in
patch-building).

An alternative is to use ObjectTemplateBuilders.