### PR TITLE
With the change, running bazel test //examples/patchbuilder/... faile…

### DIFF
--- a/examples/patchbuilder/service-patch.yaml
+++ b/examples/patchbuilder/service-patch.yaml
@@ -22,4 +22,6 @@ template: |
   spec:
     ports:
     - port: 80
+      {{if ge .Port 1}}
       targetPort: {{.Port}}
+      {{end}}


### PR DESCRIPTION
…d with:

        componentsuite.go:132: got error "while applying options to patch template 0: template: patch-tmpl-0:9:9: executing \"patch-tmpl-0\" at <ge .Port 1>: error calling ge: incompatible types for comparison" but expected no error