### PR TITLE
Update the "success: patch with numbers (floats)" patch test to repro…

### DIFF
--- a/pkg/options/patchtmpl/patch_test.go
+++ b/pkg/options/patchtmpl/patch_test.go
@@ -491,6 +491,9 @@ spec:
 
 		{
 			desc: "success: patch with numbers (floats)",
+			opts: map[string]interface{}{
+				"Port": 80,
+			},
 			component: `
 kind: Component
 spec:


### PR DESCRIPTION
…duce integer option apply issue.

With the change, running `bazel test //pkg/options/patchtmpl/..` failed
with the following error:
--- FAIL: TestPatch (0.04s)
    --- FAIL: TestPatch/success:_patch_with_numbers_(floats) (0.00s)
        patch_test.go:609: got error "applying schema defaults for patch template 0, kind: Pod\nmetadata:\n  namespace: {{.Name}}\nspec:\n  containers:\n    - name: hello-app\n      {{if ge .Port 1.0}}\n      ports:\n      - containerPort: {{.Port}}\n      {{end}}\n: validation failure list:\nPort in body must be of type number: \"string\"" but expected no error
FAIL