### PR TITLE
Wrap master address with quotes.

### DIFF
--- a/examples/cluster/kubeproxy/kubeproxy.yaml
+++ b/examples/cluster/kubeproxy/kubeproxy.yaml
@@ -43,7 +43,7 @@ spec:
         - kube-proxy {{cluster_cidr}} --resource-container="" --oom-score-adj=-998 {{params}} 1>>/var/log/kube-proxy.log 2>&1
         env:
         - name: KUBERNETES_SERVICE_HOST
-          value: "{{kubernetes_service_host_env_value}}"
+          value: "\"{{kubernetes_service_host_env_value}}\""
         securityContext:
           privileged: true
         volumeMounts:


### PR DESCRIPTION
The existing quotes get removed during template processing, resulting in the IP address being inserted into the yaml verbatim. This works with IPv4 addresses, but causes parsing errors with IPv6 addresses.